### PR TITLE
fix: align Codex plugin license metadata

### DIFF
--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -5,7 +5,7 @@
   "author": {
     "name": "Loom"
   },
-  "license": "UNLICENSED",
+  "license": "Apache-2.0",
   "keywords": [
     "codex",
     "delivery",


### PR DESCRIPTION
## Summary
- update the Codex plugin manifest license to Apache-2.0
- keep plugin metadata aligned with the package license

## Validation
- python3 /Users/xieyiting/.codex/skills/.system/plugin-creator/scripts/validate_plugin.py /Users/xieyiting/Downloads/work/valkor/loom/plugins/codex