### PR TITLE
docs: remove related work from README header

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@
     ·
     <a href="#token-saving-context">Token Saving</a>
     ·
-    <a href="#related-work">Related Work</a>
-    ·
     <a href="#faq">FAQ</a>
   </p>
   <p>


### PR DESCRIPTION
## Summary
- remove the Related Work link from the README header navigation
- keep the Related Work section in the README body

## Validation
- git diff --check