### PR TITLE
ci: publish GitHub release installer assetsFeatures/20260629 fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,139 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag, for example v0.1.0"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  package:
+    name: Package ${{ matrix.platform }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: darwin-arm64
+            os: macos-14
+            setup: src/rust/target/release/loom-setup
+          - platform: darwin-x64
+            os: macos-13
+            setup: src/rust/target/release/loom-setup
+          - platform: linux-x64
+            os: ubuntu-22.04
+            setup: src/rust/target/release/loom-setup
+          - platform: linux-arm64
+            os: ubuntu-24.04-arm
+            setup: src/rust/target/release/loom-setup
+          - platform: windows-x64
+            os: windows-latest
+            setup: src/rust/target/release/loom-setup.exe
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build release binaries
+        run: cargo build --release -p mcp-server -p setup --manifest-path src/rust/Cargo.toml
+
+      - name: Create package layout
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p dist/packages dist/release
+          "${{ matrix.setup }}" package-layout \
+            --output-dir dist/packages \
+            --platform "${{ matrix.platform }}"
+
+      - name: Create release archive
+        shell: bash
+        run: |
+          set -euo pipefail
+          package_root="$(find dist/packages -mindepth 1 -maxdepth 1 -type d -name 'loom-*' | sort | head -n 1)"
+          if [ -z "$package_root" ]; then
+            echo "No package root produced for ${{ matrix.platform }}" >&2
+            exit 1
+          fi
+          "${{ matrix.setup }}" package-archive \
+            --package-root "$package_root" \
+            --output-dir dist/release \
+            --platform "${{ matrix.platform }}"
+
+      - name: Upload package artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-${{ matrix.platform }}
+          path: dist/release/*
+          if-no-files-found: error
+
+  release:
+    name: Publish GitHub release
+    needs: package
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download package artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist/release
+          merge-multiple: true
+
+      - name: Add installer assets
+        run: |
+          set -euo pipefail
+          cp install.sh install.ps1 dist/release/
+          (cd dist/release && sha256sum install.sh > install.sh.sha256)
+          (cd dist/release && sha256sum install.ps1 > install.ps1.sha256)
+
+      - name: Verify release asset set
+        run: |
+          set -euo pipefail
+          tag="${{ github.event.inputs.tag || github.ref_name }}"
+          version="${tag#v}"
+          expected=(
+            install.sh
+            install.sh.sha256
+            install.ps1
+            install.ps1.sha256
+            "loom-${version}-darwin-arm64.tar.gz"
+            "loom-${version}-darwin-arm64.tar.gz.sha256"
+            "loom-${version}-darwin-x64.tar.gz"
+            "loom-${version}-darwin-x64.tar.gz.sha256"
+            "loom-${version}-linux-x64.tar.gz"
+            "loom-${version}-linux-x64.tar.gz.sha256"
+            "loom-${version}-linux-arm64.tar.gz"
+            "loom-${version}-linux-arm64.tar.gz.sha256"
+            "loom-${version}-windows-x64.zip"
+            "loom-${version}-windows-x64.zip.sha256"
+          )
+          for file in "${expected[@]}"; do
+            test -f "dist/release/$file" || {
+              echo "Missing release asset: $file" >&2
+              find dist/release -maxdepth 1 -type f -print | sort >&2
+              exit 1
+            }
+          done
+
+      - name: Publish release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.event.inputs.tag || github.ref_name }}
+          name: Loom ${{ github.event.inputs.tag || github.ref_name }}
+          files: dist/release/*
+          fail_on_unmatched_files: true
+          make_latest: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,18 +25,28 @@ jobs:
           - platform: darwin-arm64
             os: macos-14
             setup: src/rust/target/release/loom-setup
+            rust_target: ""
+            binary_dir: src/rust/target/release
           - platform: darwin-x64
-            os: macos-13
+            os: macos-14
             setup: src/rust/target/release/loom-setup
+            rust_target: x86_64-apple-darwin
+            binary_dir: src/rust/target/x86_64-apple-darwin/release
           - platform: linux-x64
             os: ubuntu-22.04
             setup: src/rust/target/release/loom-setup
+            rust_target: ""
+            binary_dir: src/rust/target/release
           - platform: linux-arm64
             os: ubuntu-24.04-arm
             setup: src/rust/target/release/loom-setup
+            rust_target: ""
+            binary_dir: src/rust/target/release
           - platform: windows-x64
             os: windows-latest
             setup: src/rust/target/release/loom-setup.exe
+            rust_target: ""
+            binary_dir: src/rust/target/release
 
     steps:
       - name: Checkout
@@ -45,14 +55,26 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Install Rust target
+        if: matrix.rust_target != ''
+        run: rustup target add ${{ matrix.rust_target }}
+
       - name: Build release binaries
+        if: matrix.rust_target == ''
         run: cargo build --release -p mcp-server -p setup --manifest-path src/rust/Cargo.toml
+
+      - name: Build cross-target release binaries
+        if: matrix.rust_target != ''
+        run: |
+          cargo build --release -p setup --manifest-path src/rust/Cargo.toml
+          cargo build --release -p mcp-server -p setup --manifest-path src/rust/Cargo.toml --target ${{ matrix.rust_target }}
 
       - name: Create package layout
         shell: bash
         run: |
           set -euo pipefail
           mkdir -p dist/packages dist/release
+          export LOOM_SETUP_BINARY_DIR="$PWD/${{ matrix.binary_dir }}"
           "${{ matrix.setup }}" package-layout \
             --output-dir dist/packages \
             --platform "${{ matrix.platform }}"

--- a/tests/rust/setup/setup_workflow.rs
+++ b/tests/rust/setup/setup_workflow.rs
@@ -382,6 +382,32 @@ fn install_ps1_release_contract_uses_windows_zip_checksum_and_doctor() {
 }
 
 #[test]
+fn release_workflow_uploads_installers_packages_and_checksums() {
+    let workflow = fs::read_to_string(repo_root().join(".github/workflows/release.yml")).unwrap();
+    assert!(workflow.contains("tags:"));
+    assert!(workflow.contains("- \"v*\""));
+    assert!(workflow.contains("contents: write"));
+    for platform in [
+        "darwin-arm64",
+        "darwin-x64",
+        "linux-x64",
+        "linux-arm64",
+        "windows-x64",
+    ] {
+        assert!(workflow.contains(platform), "missing platform {platform}");
+    }
+    assert!(workflow.contains("loom-setup.exe"));
+    assert!(workflow.contains("install.sh"));
+    assert!(workflow.contains("install.ps1"));
+    assert!(workflow.contains("install.sh.sha256"));
+    assert!(workflow.contains("install.ps1.sha256"));
+    assert!(workflow.contains(".tar.gz.sha256"));
+    assert!(workflow.contains(".zip.sha256"));
+    assert!(workflow.contains("softprops/action-gh-release@v2"));
+    assert!(workflow.contains("make_latest: true"));
+}
+
+#[test]
 fn archive_package_layout_rejects_legacy_typescript_runtime_entries() {
     let fixture = Fixture::new("archive_rejects_legacy_runtime");
     fixture.write_package();


### PR DESCRIPTION
## Summary

This PR adds the missing GitHub Release automation required for the public Loom installer commands to work.

## Changes

- Add a `Release` GitHub Actions workflow triggered by `v*` tags.
- Build release packages for:
  - macOS arm64
  - macOS x64
  - Linux x64
  - Linux arm64
  - Windows x64
- Upload release assets:
  - `install.sh`
  - `install.ps1`
  - platform archives
  - `.sha256` checksum files
- Mark the generated GitHub Release as latest.
- Avoid long macOS x64 runner queues by cross-compiling `darwin-x64` from `macos-14`.
- Add setup workflow tests to ensure release installers, platform packages, and checksum assets are included.

## Validation

Ran:

```bash
cargo fmt --all
cargo test --manifest-path src/rust/Cargo.toml --test setup_workflow
cargo test --manifest-path src/rust/Cargo.toml --test setup_workflow release_workflow_uploads_installers_packages_and_checksums
git diff --check
```

Verified the public installer command now works:

```bash
curl -fsSL https://github.com/valkor-ai/loom/releases/latest/download/install.sh | bash -s -- --agent codex
```

Result:

- `install` returned `status: ok`
- `doctor` returned `status: ok`

## Notes

`v0.1.0` has already been published and verified from this branch. After this PR is merged, future releases should be tagged from `main`.