### PR TITLE
update release actions and improve deploy workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Release tag, for example v0.2.0"
+        description: "Release tag, for example v0.2.1"
         required: true
         type: string
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -94,7 +94,7 @@ jobs:
             --platform "${{ matrix.platform }}"
 
       - name: Upload package artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-${{ matrix.platform }}
           path: dist/release/*
@@ -107,10 +107,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Download package artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: dist/release
           merge-multiple: true
@@ -152,7 +152,7 @@ jobs:
           done
 
       - name: Publish release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.event.inputs.tag || github.ref_name }}
           name: Loom ${{ github.event.inputs.tag || github.ref_name }}

--- a/install.ps1
+++ b/install.ps1
@@ -6,7 +6,7 @@ param(
   [string]$Agent,
 
   [Alias("version")]
-  [string]$Version = "0.2.0",
+  [string]$Version = "0.2.1",
 
   [Alias("baseUrl")]
   [string]$BaseUrl = "https://github.com/valkor-ai/loom/releases/latest/download",

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 set -eu
 
 AGENT=""
-VERSION="0.2.0"
+VERSION="0.2.1"
 VERSION_FROM_ARGS=0
 BASE_URL="https://github.com/valkor-ai/loom/releases/latest/download"
 BASE_URL_FROM_ARGS=0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loom",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A delivery layer for coding agents that turns product requests into planned, verified, deployable software changes.",
   "license": "Apache-2.0",
   "private": true,

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "algorithm-client"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "serde_json",
 ]
@@ -61,7 +61,7 @@ dependencies = [
 
 [[package]]
 name = "architecture"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "contracts",
  "delivery-core",
@@ -120,7 +120,7 @@ dependencies = [
 
 [[package]]
 name = "brainstorm"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "algorithm-client",
  "contracts",
@@ -228,7 +228,7 @@ checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "contracts"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "delivery-core",
  "schemars",
@@ -327,7 +327,7 @@ checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
 
 [[package]]
 name = "delivery-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "schemars",
  "serde",
@@ -337,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "deploy"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "contracts",
  "delivery-core",
@@ -428,7 +428,7 @@ dependencies = [
 
 [[package]]
 name = "execution"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "brainstorm",
  "contracts",
@@ -661,7 +661,7 @@ dependencies = [
 
 [[package]]
 name = "knowledge"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "algorithm-client",
  "chrono",
@@ -734,7 +734,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-server"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "architecture",
@@ -878,7 +878,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "planning"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "brainstorm",
  "contracts",
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "setup"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "chrono",
  "delivery-core",
@@ -1227,7 +1227,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "state"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "delivery-core",
  "schemars",
@@ -1482,7 +1482,7 @@ checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "verification"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "delivery-core",
@@ -1650,7 +1650,7 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "workflow"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "architecture",
  "brainstorm",

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/valkor-ai/loom"

--- a/src/rust/contracts/deploy.rs
+++ b/src/rust/contracts/deploy.rs
@@ -414,13 +414,27 @@ pub struct DeploymentGeneratedFiles {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct DeploymentRuntime {
-    pub host_port: u16,
+pub struct DeploymentRuntimePort {
+    pub service_id: String,
+    pub purpose: String,
     pub container_port: u16,
-    pub url: String,
-    pub preview_path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub preferred_host_port: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub host_port: Option<u16>,
+    pub path: String,
+    pub internal_only: bool,
+    pub protocol: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct DeploymentRuntime {
+    pub primary_service_id: String,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub api_paths: Vec<String>,
+    pub ports: Vec<DeploymentRuntimePort>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]

--- a/src/rust/contracts/deploy.rs
+++ b/src/rust/contracts/deploy.rs
@@ -403,9 +403,10 @@ pub struct DeploymentBootstrapDiagnostics {
 #[serde(rename_all = "camelCase")]
 pub struct DeploymentGeneratedFiles {
     pub compose_path: String,
-    pub dockerignore_path: String,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub dockerfile_paths: BTreeMap<String, String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub dockerignore_paths: BTreeMap<String, String>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub nginx_config_paths: BTreeMap<String, String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]

--- a/src/rust/deploy/active_operation.rs
+++ b/src/rust/deploy/active_operation.rs
@@ -134,6 +134,23 @@ pub fn acquire_operation(
     }))
 }
 
+pub fn update_operation_phase(project_root: &Path, phase: &str, status: &str) -> StateResult<()> {
+    let paths = deployment_paths(project_root);
+    if !path_exists(&paths.active_operation_file) {
+        return Ok(());
+    }
+    let mut operation: DeploymentActiveOperation = read_json(&paths.active_operation_file)?;
+    operation.phase = phase.to_string();
+    operation.status = status.to_string();
+    operation.updated_at = now_string();
+    operation.spec_ref = if path_exists(&paths.spec_file) {
+        Some(to_project_relative(project_root, &paths.spec_file)?)
+    } else {
+        None
+    };
+    write_json_atomic(&paths.active_operation_file, &operation)
+}
+
 pub fn live_operation(project_root: &Path) -> StateResult<Option<DeploymentActiveOperation>> {
     let paths = deployment_paths(project_root);
     if !path_exists(&paths.active_operation_file) {

--- a/src/rust/deploy/active_operation.rs
+++ b/src/rust/deploy/active_operation.rs
@@ -151,6 +151,21 @@ pub fn update_operation_phase(project_root: &Path, phase: &str, status: &str) ->
     write_json_atomic(&paths.active_operation_file, &operation)
 }
 
+pub fn touch_operation(project_root: &Path) -> StateResult<()> {
+    let paths = deployment_paths(project_root);
+    if !path_exists(&paths.active_operation_file) {
+        return Ok(());
+    }
+    let mut operation: DeploymentActiveOperation = read_json(&paths.active_operation_file)?;
+    operation.updated_at = now_string();
+    operation.spec_ref = if path_exists(&paths.spec_file) {
+        Some(to_project_relative(project_root, &paths.spec_file)?)
+    } else {
+        None
+    };
+    write_json_atomic(&paths.active_operation_file, &operation)
+}
+
 pub fn live_operation(project_root: &Path) -> StateResult<Option<DeploymentActiveOperation>> {
     let paths = deployment_paths(project_root);
     if !path_exists(&paths.active_operation_file) {

--- a/src/rust/deploy/code_evidence.rs
+++ b/src/rust/deploy/code_evidence.rs
@@ -86,11 +86,7 @@ pub fn build_deployment_code_probe(project_root: &Path) -> StateResult<Deploymen
         } else {
             vec![]
         };
-        let framework = if has_web {
-            Some("spring-boot+vite-react".to_string())
-        } else {
-            Some("spring-boot".to_string())
-        };
+        let framework = Some("spring-boot".to_string());
         let build_command = if has_service_gradle {
             Some("cd service && chmod +x ./gradlew && ./gradlew bootJar --no-daemon".to_string())
         } else {

--- a/src/rust/deploy/generate.rs
+++ b/src/rust/deploy/generate.rs
@@ -413,7 +413,9 @@ fn generate_app_service(spec: &DeploymentSpec, service: &DeploymentSourceService
         .parent()
         .and_then(Path::to_str)
         .unwrap_or(".");
-    let dockerfile = project_path_relative_to_directory(compose_dir, &dockerfile_project_path);
+    let build_context_dir = project_path_join(compose_dir, &spec.source_model.build_context_path);
+    let dockerfile =
+        project_path_relative_to_directory(&build_context_dir, &dockerfile_project_path);
     let mut env = runtime_env(service);
     if service.role != SourceServiceRole::Frontend {
         for dependency in &spec.source_model.dependencies {
@@ -720,11 +722,33 @@ fn project_path_relative_to_directory(
     }
 }
 
+fn project_path_join(base_project_relative_directory: &str, relative_path: &str) -> String {
+    let value = match (base_project_relative_directory, relative_path) {
+        ("", path) | (".", path) => path.to_string(),
+        (base, "") | (base, ".") => base.to_string(),
+        (base, path) => format!("{base}/{path}"),
+    };
+    let parts = normalized_relative_parts(&value);
+    if parts.is_empty() {
+        ".".to_string()
+    } else {
+        parts.join("/")
+    }
+}
+
 fn normalized_relative_parts(value: &str) -> Vec<&str> {
-    value
-        .split('/')
-        .filter(|part| !part.is_empty() && *part != ".")
-        .collect()
+    let mut parts = Vec::new();
+    for part in value.split('/') {
+        if part.is_empty() || part == "." {
+            continue;
+        }
+        if part == ".." {
+            let _ = parts.pop();
+        } else {
+            parts.push(part);
+        }
+    }
+    parts
 }
 
 fn normalize_nginx_public_path(value: &str) -> String {

--- a/src/rust/deploy/generate.rs
+++ b/src/rust/deploy/generate.rs
@@ -23,6 +23,7 @@ pub fn generated_file_refs(
     topology: &DeploymentTopology,
 ) -> state::store::StateResult<DeploymentGeneratedFiles> {
     let mut dockerfile_paths = BTreeMap::new();
+    let mut dockerignore_paths = BTreeMap::new();
     let mut nginx_config_paths = BTreeMap::new();
     for service in &source_model.services {
         dockerfile_paths.insert(
@@ -30,6 +31,13 @@ pub fn generated_file_refs(
             to_project_relative(
                 project_root,
                 &paths::dockerfile_path(project_root, &service.service_id),
+            )?,
+        );
+        dockerignore_paths.insert(
+            service.service_id.clone(),
+            to_project_relative(
+                project_root,
+                &paths::dockerfile_ignore_path(project_root, &service.service_id),
             )?,
         );
         if service.service_id == topology.public_entry_service_id
@@ -51,8 +59,8 @@ pub fn generated_file_refs(
     let deployment_paths = paths::deployment_paths(project_root);
     Ok(DeploymentGeneratedFiles {
         compose_path: to_project_relative(project_root, &deployment_paths.compose_file)?,
-        dockerignore_path: to_project_relative(project_root, &deployment_paths.dockerignore_file)?,
         dockerfile_paths,
+        dockerignore_paths,
         nginx_config_paths,
         reused: vec![],
     })
@@ -180,8 +188,8 @@ fn generate_node_dockerfile(service: &DeploymentSourceService) -> String {
 }
 
 fn generate_java_dockerfile(service: &DeploymentSourceService) -> String {
-    if java_service_has_frontend_overlay(service) {
-        return generate_java_with_frontend_dockerfile(service);
+    if java_service_needs_static_asset_overlay(service) {
+        return generate_java_dockerfile_with_static_asset_overlay(service);
     }
     let build_command = service
         .build_command
@@ -217,7 +225,7 @@ fn generate_java_dockerfile(service: &DeploymentSourceService) -> String {
     .join("\n")
 }
 
-fn generate_java_with_frontend_dockerfile(service: &DeploymentSourceService) -> String {
+fn generate_java_dockerfile_with_static_asset_overlay(service: &DeploymentSourceService) -> String {
     let frontend_root =
         frontend_root_from_package_refs(service).unwrap_or_else(|| "web".to_string());
     let frontend_output = service
@@ -260,7 +268,7 @@ fn generate_java_with_frontend_dockerfile(service: &DeploymentSourceService) -> 
     .join("\n")
 }
 
-fn java_service_has_frontend_overlay(service: &DeploymentSourceService) -> bool {
+fn java_service_needs_static_asset_overlay(service: &DeploymentSourceService) -> bool {
     service.runtime_kind == RuntimeKind::Java
         && !service.workspace_package_json_paths.is_empty()
         && service.output_directory.is_some()
@@ -355,7 +363,10 @@ fn generate_dotnet_dockerfile(service: &DeploymentSourceService) -> String {
 }
 
 fn generate_compose(spec: &DeploymentSpec) -> String {
-    let mut lines = vec!["services:".to_string()];
+    let mut lines = vec![
+        format!("name: {}", yaml_string(&spec.service_name)),
+        "services:".to_string(),
+    ];
     for service in &spec.source_model.services {
         lines.extend(generate_app_service(spec, service));
     }

--- a/src/rust/deploy/generate.rs
+++ b/src/rust/deploy/generate.rs
@@ -1,13 +1,13 @@
 use std::{collections::BTreeMap, path::Path};
 
 use contracts::{
-    DependencyService, DeploymentGeneratedFiles, DeploymentRoute, DeploymentRuntime,
-    DeploymentRuntimeContract, DeploymentSourceModel, DeploymentSourceService, DeploymentSpec,
-    DeploymentTopology, PackageManager, RuntimeKind, SourceServiceRole,
+    DependencyService, DeploymentGeneratedFiles, DeploymentRoute, DeploymentSourceModel,
+    DeploymentSourceService, DeploymentSpec, DeploymentTopology, PackageManager, RuntimeKind,
+    SourceServiceRole,
 };
 use state::paths::to_project_relative;
 
-use crate::{paths, topology::proxy_target_service_ids};
+use crate::{paths, port_plan::host_port_for_service, topology::proxy_target_service_ids};
 
 #[derive(Debug, Clone)]
 pub struct GeneratedDeploymentText {
@@ -56,26 +56,6 @@ pub fn generated_file_refs(
         nginx_config_paths,
         reused: vec![],
     })
-}
-
-pub fn deployment_runtime(
-    runtime_contract: &DeploymentRuntimeContract,
-    source_model: &DeploymentSourceModel,
-    host_port: u16,
-) -> DeploymentRuntime {
-    let preview = source_model
-        .services
-        .iter()
-        .find(|service| service.service_id == source_model.preview_service_id)
-        .or_else(|| source_model.services.first());
-    let container_port = preview.map(|service| service.port).unwrap_or(8080);
-    DeploymentRuntime {
-        host_port,
-        container_port,
-        url: format!("http://localhost:{host_port}"),
-        preview_path: runtime_contract.preview_path.clone(),
-        api_paths: runtime_contract.api_paths.clone(),
-    }
 }
 
 pub fn generate_deployment_files(spec: &DeploymentSpec) -> GeneratedDeploymentText {
@@ -434,12 +414,9 @@ fn generate_app_service(spec: &DeploymentSpec, service: &DeploymentSourceService
         format!("      dockerfile: {}", yaml_string(&dockerfile)),
         format!("    image: {}-{}", spec.image_name, service.service_id),
     ];
-    if service.service_id == spec.source_model.preview_service_id {
+    if let Some(host_port) = host_port_for_service(&spec.runtime, &service.service_id) {
         lines.push("    ports:".to_string());
-        lines.push(format!(
-            "      - \"{}:{}\"",
-            spec.runtime.host_port, service.port
-        ));
+        lines.push(format!("      - \"{}:{}\"", host_port, service.port));
     }
     lines.extend(yaml_environment(&env, 4));
     if service.start_command.is_some() {

--- a/src/rust/deploy/lib.rs
+++ b/src/rust/deploy/lib.rs
@@ -7,6 +7,7 @@ mod generate;
 mod inspect;
 mod logs;
 mod paths;
+mod port_plan;
 mod prepare;
 mod repair;
 mod run;

--- a/src/rust/deploy/paths.rs
+++ b/src/rust/deploy/paths.rs
@@ -19,7 +19,6 @@ pub struct DeploymentPaths {
     pub code_evidence_file: PathBuf,
     pub generated_dir: PathBuf,
     pub compose_file: PathBuf,
-    pub dockerignore_file: PathBuf,
 }
 
 pub fn deployment_paths(project_root: &Path) -> DeploymentPaths {
@@ -40,7 +39,6 @@ pub fn deployment_paths(project_root: &Path) -> DeploymentPaths {
         failure_file: state_dir.join("latest-failure.json"),
         code_evidence_file: evidence_dir.join("latest-code-evidence.json"),
         compose_file: generated_dir.join("compose.yaml"),
-        dockerignore_file: generated_dir.join("Dockerfile.dockerignore"),
         specs_dir,
         state_dir,
         logs_dir,

--- a/src/rust/deploy/paths.rs
+++ b/src/rust/deploy/paths.rs
@@ -56,6 +56,12 @@ pub fn dockerfile_path(project_root: &Path, service_id: &str) -> PathBuf {
         .join(format!("Dockerfile.{service_id}"))
 }
 
+pub fn dockerfile_ignore_path(project_root: &Path, service_id: &str) -> PathBuf {
+    deployment_paths(project_root)
+        .generated_dir
+        .join(format!("Dockerfile.{service_id}.dockerignore"))
+}
+
 pub fn nginx_config_path(project_root: &Path, service_id: &str) -> PathBuf {
     deployment_paths(project_root)
         .generated_dir

--- a/src/rust/deploy/port_plan.rs
+++ b/src/rust/deploy/port_plan.rs
@@ -1,0 +1,234 @@
+use std::{collections::BTreeSet, net::TcpListener};
+
+use contracts::{
+    DependencyService, DeploymentComposeInfo, DeploymentRoute, DeploymentRuntime,
+    DeploymentRuntimeContract, DeploymentRuntimePort, DeploymentSourceModel,
+    DeploymentSourceService, DeploymentTopology, SourceServiceRole,
+};
+
+pub fn build_deployment_runtime(
+    runtime_contract: &DeploymentRuntimeContract,
+    source_model: &DeploymentSourceModel,
+    topology: &DeploymentTopology,
+    compose_info: Option<&DeploymentComposeInfo>,
+) -> DeploymentRuntime {
+    let compose_ports = selected_compose_ports(compose_info);
+    let mut allocated = BTreeSet::new();
+    let mut ports = Vec::new();
+
+    for service in &source_model.services {
+        let purpose = service_purpose(source_model, topology, service);
+        let internal_only = service.service_id != topology.public_entry_service_id
+            && service.service_id != source_model.preview_service_id;
+        let compose_port = compose_ports
+            .iter()
+            .find(|port| port.container_port == service.port)
+            .or_else(|| {
+                (service.service_id == source_model.preview_service_id)
+                    .then(|| compose_ports.first())
+                    .flatten()
+            });
+        let fixed_compose_host_port = compose_port.and_then(|port| port.host_port);
+        let preferred = compose_port
+            .and_then(|port| port.host_port)
+            .or_else(|| (!internal_only).then(|| preferred_host_port(service)));
+        let host_port = if internal_only {
+            None
+        } else if let Some(port) = fixed_compose_host_port {
+            Some(port)
+        } else {
+            Some(resolve_host_port(
+                preferred.unwrap_or_else(|| preferred_host_port(service)),
+                &mut allocated,
+            ))
+        };
+        let path = service_path(runtime_contract, topology, service);
+        ports.push(DeploymentRuntimePort {
+            service_id: service.service_id.clone(),
+            purpose,
+            container_port: compose_port
+                .map(|port| port.container_port)
+                .unwrap_or(service.port),
+            preferred_host_port: preferred,
+            host_port,
+            path: path.clone(),
+            internal_only,
+            protocol: "http".to_string(),
+            url: host_port.map(|port| url_for(port, &path)),
+        });
+    }
+
+    for dependency in &source_model.dependencies {
+        ports.push(dependency_port(dependency));
+    }
+
+    DeploymentRuntime {
+        primary_service_id: source_model.preview_service_id.clone(),
+        ports,
+    }
+}
+
+pub fn primary_url(runtime: &DeploymentRuntime) -> String {
+    runtime
+        .ports
+        .iter()
+        .find(|port| port.service_id == runtime.primary_service_id && !port.internal_only)
+        .and_then(|port| port.url.clone())
+        .or_else(|| {
+            runtime
+                .ports
+                .iter()
+                .find(|port| !port.internal_only)
+                .and_then(|port| port.url.clone())
+        })
+        .unwrap_or_else(|| "http://localhost".to_string())
+}
+
+pub fn primary_public_port(runtime: &DeploymentRuntime) -> Option<u16> {
+    runtime
+        .ports
+        .iter()
+        .find(|port| port.service_id == runtime.primary_service_id && !port.internal_only)
+        .and_then(|port| port.host_port)
+        .or_else(|| {
+            runtime
+                .ports
+                .iter()
+                .find(|port| !port.internal_only)
+                .and_then(|port| port.host_port)
+        })
+}
+
+pub fn host_port_for_service(runtime: &DeploymentRuntime, service_id: &str) -> Option<u16> {
+    runtime
+        .ports
+        .iter()
+        .find(|port| port.service_id == service_id && !port.internal_only)
+        .and_then(|port| port.host_port)
+}
+
+fn selected_compose_ports(
+    compose_info: Option<&DeploymentComposeInfo>,
+) -> Vec<contracts::DeploymentComposePort> {
+    let Some(info) = compose_info else {
+        return Vec::new();
+    };
+    let Some(selected) = info.selected_service.as_ref() else {
+        return Vec::new();
+    };
+    info.services
+        .iter()
+        .find(|service| &service.name == selected)
+        .map(|service| service.ports.clone())
+        .unwrap_or_default()
+}
+
+fn service_purpose(
+    source_model: &DeploymentSourceModel,
+    topology: &DeploymentTopology,
+    service: &DeploymentSourceService,
+) -> String {
+    if service.service_id == source_model.preview_service_id {
+        return "preview".to_string();
+    }
+    if topology.routes.iter().any(|route| {
+        matches!(
+            route,
+            DeploymentRoute::HttpProxy {
+                target_service_id,
+                ..
+            } if target_service_id == &service.service_id
+        )
+    }) || service.role == SourceServiceRole::Backend
+    {
+        return "api".to_string();
+    }
+    "service".to_string()
+}
+
+fn service_path(
+    runtime_contract: &DeploymentRuntimeContract,
+    topology: &DeploymentTopology,
+    service: &DeploymentSourceService,
+) -> String {
+    if service.service_id == topology.public_entry_service_id {
+        return normalize_path(&runtime_contract.preview_path);
+    }
+    topology
+        .routes
+        .iter()
+        .find_map(|route| match route {
+            DeploymentRoute::HttpProxy {
+                public_path,
+                target_service_id,
+                ..
+            } if target_service_id == &service.service_id => Some(normalize_path(public_path)),
+            _ => None,
+        })
+        .or_else(|| service.healthcheck_path.as_deref().map(normalize_path))
+        .unwrap_or_else(|| "/".to_string())
+}
+
+fn dependency_port(dependency: &DependencyService) -> DeploymentRuntimePort {
+    DeploymentRuntimePort {
+        service_id: dependency.service_name.clone(),
+        purpose: "dependency".to_string(),
+        container_port: dependency.port,
+        preferred_host_port: None,
+        host_port: None,
+        path: "/".to_string(),
+        internal_only: true,
+        protocol: "tcp".to_string(),
+        url: None,
+    }
+}
+
+fn preferred_host_port(service: &DeploymentSourceService) -> u16 {
+    if service.role == SourceServiceRole::Frontend && service.port == 80 {
+        4173
+    } else {
+        service.port
+    }
+}
+
+fn resolve_host_port(preferred: u16, allocated: &mut BTreeSet<u16>) -> u16 {
+    for range in [preferred..=u16::MAX, 1024..=preferred] {
+        for port in range {
+            if allocated.contains(&port) {
+                continue;
+            }
+            if TcpListener::bind(("127.0.0.1", port)).is_ok() {
+                allocated.insert(port);
+                return port;
+            }
+        }
+    }
+    preferred
+}
+
+fn url_for(host_port: u16, path: &str) -> String {
+    let path = normalize_path(path);
+    if path == "/" {
+        format!("http://localhost:{host_port}")
+    } else {
+        format!("http://localhost:{host_port}{path}")
+    }
+}
+
+fn normalize_path(value: &str) -> String {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return "/".to_string();
+    }
+    let path = trimmed.split(['?', '#']).next().unwrap_or("/");
+    let path = if path.starts_with('/') {
+        path.to_string()
+    } else {
+        format!("/{path}")
+    };
+    if path.len() > 1 {
+        path.trim_end_matches('/').to_string()
+    } else {
+        path
+    }
+}

--- a/src/rust/deploy/prepare.rs
+++ b/src/rust/deploy/prepare.rs
@@ -198,13 +198,16 @@ pub fn deploy_prepare_inner(
         DeployProvider::ComposeExisting => {}
         DeployProvider::DockerfileExisting => {
             write_text_atomic(&paths.compose_file, &generated.compose)?;
-            write_text_atomic(&paths.dockerignore_file, &generated.dockerignore)?;
         }
         DeployProvider::Generated => {
             for (service_id, content) in &generated.dockerfiles {
                 write_text_atomic(
                     &crate::paths::dockerfile_path(project_root, service_id),
                     content,
+                )?;
+                write_text_atomic(
+                    &crate::paths::dockerfile_ignore_path(project_root, service_id),
+                    &generated.dockerignore,
                 )?;
             }
             for (service_id, content) in &generated.nginx_configs {
@@ -214,7 +217,6 @@ pub fn deploy_prepare_inner(
                 )?;
             }
             write_text_atomic(&paths.compose_file, &generated.compose)?;
-            write_text_atomic(&paths.dockerignore_file, &generated.dockerignore)?;
         }
     }
     write_json_atomic(&paths.spec_file, &spec)?;
@@ -494,11 +496,16 @@ pub(crate) fn deployment_prepare_details(
 }
 
 pub(crate) fn deployment_file_refs(spec: &DeploymentSpec) -> Vec<String> {
-    let mut refs = vec![
-        spec.files.compose_path.clone(),
-        spec.files.dockerignore_path.clone(),
-    ];
+    let mut refs = vec![spec.files.compose_path.clone()];
     refs.extend(spec.files.dockerfile_paths.values().cloned());
+    if spec.provider == DeployProvider::Generated {
+        refs.extend(
+            spec.files
+                .dockerfile_paths
+                .values()
+                .map(|path| format!("{path}.dockerignore")),
+        );
+    }
     refs.extend(spec.files.nginx_config_paths.values().cloned());
     refs.sort();
     refs.dedup();

--- a/src/rust/deploy/prepare.rs
+++ b/src/rust/deploy/prepare.rs
@@ -345,8 +345,8 @@ fn deployment_files_for_provider(
             }
             Ok(DeploymentGeneratedFiles {
                 compose_path: to_project_relative(project_root, &paths.compose_file)?,
-                dockerignore_path: to_project_relative(project_root, &paths.dockerignore_file)?,
                 dockerfile_paths,
+                dockerignore_paths: BTreeMap::new(),
                 nginx_config_paths: BTreeMap::new(),
                 reused: vec![dockerfile_ref],
             })
@@ -365,8 +365,8 @@ fn deployment_files_for_provider(
             reused.dedup();
             Ok(DeploymentGeneratedFiles {
                 compose_path: to_project_relative(project_root, compose_path)?,
-                dockerignore_path: to_project_relative(project_root, &paths.dockerignore_file)?,
                 dockerfile_paths: BTreeMap::new(),
+                dockerignore_paths: BTreeMap::new(),
                 nginx_config_paths: BTreeMap::new(),
                 reused,
             })
@@ -501,14 +501,7 @@ pub(crate) fn deployment_prepare_details(
 pub(crate) fn deployment_file_refs(spec: &DeploymentSpec) -> Vec<String> {
     let mut refs = vec![spec.files.compose_path.clone()];
     refs.extend(spec.files.dockerfile_paths.values().cloned());
-    if spec.provider == DeployProvider::Generated {
-        refs.extend(
-            spec.files
-                .dockerfile_paths
-                .values()
-                .map(|path| format!("{path}.dockerignore")),
-        );
-    }
+    refs.extend(spec.files.dockerignore_paths.values().cloned());
     refs.extend(spec.files.nginx_config_paths.values().cloned());
     refs.sort();
     refs.dedup();

--- a/src/rust/deploy/prepare.rs
+++ b/src/rust/deploy/prepare.rs
@@ -1,6 +1,5 @@
 use std::{
     collections::BTreeMap,
-    net::TcpListener,
     path::{Path, PathBuf},
 };
 
@@ -29,8 +28,9 @@ use crate::{
         analyze_existing_compose, find_existing_deployment_files, selected_compose_port,
         ExistingDeploymentFiles,
     },
-    generate::{deployment_runtime, generate_deployment_files, generated_file_refs},
+    generate::{generate_deployment_files, generated_file_refs},
     paths::{deployment_paths, DeploymentPaths},
+    port_plan::{build_deployment_runtime, primary_url},
     runtime_contract::load_runtime_contract,
     source_model::source_model_from_runtime_contract,
     strategy::resolve_deployment_strategy,
@@ -126,11 +126,12 @@ pub fn deploy_prepare_inner(
     let code_evidence_ref = to_project_relative(project_root, &paths.code_evidence_file)?;
     let environment = env_diagnostics(&runtime_contract);
     let bootstrap = analyze_deployment_bootstrap(project_root, &code_probe);
-    let host_port = compose_port
-        .as_ref()
-        .and_then(|port| port.host_port)
-        .unwrap_or_else(find_host_port);
-    let runtime = deployment_runtime(&runtime_contract, &source_model, host_port);
+    let runtime = build_deployment_runtime(
+        &runtime_contract,
+        &source_model,
+        &topology,
+        compose_info.as_ref(),
+    );
     let service_name = sanitize_name(
         deployment_root
             .file_name()
@@ -270,15 +271,6 @@ fn env_diagnostics(runtime: &contracts::DeploymentRuntimeContract) -> Deployment
         missing,
         warnings: vec![],
     }
-}
-
-fn find_host_port() -> u16 {
-    for port in 4173..4300 {
-        if TcpListener::bind(("127.0.0.1", port)).is_ok() {
-            return port;
-        }
-    }
-    4173
 }
 
 fn deployment_root_for(project_root: &Path, app_path: Option<&str>) -> StateResult<PathBuf> {
@@ -491,7 +483,18 @@ pub(crate) fn deployment_prepare_details(
         })),
         "generatedFileRefs": deployment_generated_file_refs(spec),
         "reusedFileRefs": spec.files.reused,
-        "url": spec.runtime.url
+        "primaryUrl": primary_url(&spec.runtime),
+        "ports": spec.runtime.ports.iter().map(|port| json!({
+            "serviceId": port.service_id.clone(),
+            "purpose": port.purpose.clone(),
+            "containerPort": port.container_port,
+            "preferredHostPort": port.preferred_host_port,
+            "hostPort": port.host_port,
+            "path": port.path.clone(),
+            "internalOnly": port.internal_only,
+            "protocol": port.protocol.clone(),
+            "url": port.url.clone()
+        })).collect::<Vec<_>>()
     }))
 }
 

--- a/src/rust/deploy/prepare.rs
+++ b/src/rust/deploy/prepare.rs
@@ -5,7 +5,7 @@ use std::{
 
 use contracts::{
     DeployProvider, DeploymentEnvDiagnostics, DeploymentEnvVariable, DeploymentGeneratedFiles,
-    DeploymentProviderPolicy, DeploymentSourceModel, DeploymentSpec,
+    DeploymentProviderPolicy, DeploymentRuntimeContract, DeploymentSourceModel, DeploymentSpec,
 };
 use delivery_core::{
     LoomMcpActionResult, LoomMcpBlockedResult, LoomMcpDoneResult, LoomMcpFailure,
@@ -32,7 +32,7 @@ use crate::{
     paths::{deployment_paths, DeploymentPaths},
     port_plan::{build_deployment_runtime, primary_url},
     runtime_contract::load_runtime_contract,
-    source_model::source_model_from_runtime_contract,
+    source_model::{runtime_contract_declares_multi_root, source_model_from_runtime_contract},
     strategy::resolve_deployment_strategy,
     topology::build_topology,
     DeployToolInput,
@@ -66,8 +66,13 @@ pub fn deploy_prepare_inner(
     ensure_dir(&paths.state_dir)?;
     ensure_dir(&paths.logs_dir)?;
 
-    let deployment_root = deployment_root_for(project_root, input.app_path.as_deref())?;
     let runtime_contract = load_runtime_contract(project_root)?;
+    let requested_deployment_root = deployment_root_for(project_root, input.app_path.as_deref())?;
+    let deployment_root = deployment_root_for_runtime_contract(
+        project_root,
+        requested_deployment_root,
+        &runtime_contract,
+    );
     let code_probe = build_deployment_code_probe(&deployment_root)?;
     let build_context_path = relative_context_from_generated_to_root(
         project_root,
@@ -284,6 +289,18 @@ fn deployment_root_for(project_root: &Path, app_path: Option<&str>) -> StateResu
         )));
     }
     Ok(root)
+}
+
+fn deployment_root_for_runtime_contract(
+    project_root: &Path,
+    requested_root: PathBuf,
+    runtime: &DeploymentRuntimeContract,
+) -> PathBuf {
+    if requested_root != project_root && runtime_contract_declares_multi_root(runtime) {
+        project_root.to_path_buf()
+    } else {
+        requested_root
+    }
 }
 
 fn validate_selected_provider(

--- a/src/rust/deploy/repair.rs
+++ b/src/rust/deploy/repair.rs
@@ -1117,25 +1117,7 @@ fn editable_files_for(spec: &DeploymentSpec, failure_kind: DeploymentFailureKind
         | DeploymentFailureKind::HttpProbeFailed
         | DeploymentFailureKind::PreviewNotVerified => vec![],
         _ if spec.provider == DeployProvider::ComposeExisting => vec![],
-        _ => {
-            let reused = spec
-                .files
-                .reused
-                .iter()
-                .collect::<std::collections::BTreeSet<_>>();
-            let mut files = vec![
-                spec.files.compose_path.clone(),
-                spec.files.dockerignore_path.clone(),
-            ];
-            files.extend(spec.files.nginx_config_paths.values().cloned());
-            if spec.provider == DeployProvider::Generated {
-                files.extend(spec.files.dockerfile_paths.values().cloned());
-            }
-            files.sort();
-            files.dedup();
-            files.retain(|file| !file.is_empty() && !reused.contains(file));
-            files
-        }
+        _ => deployment_generated_file_refs(spec),
     }
 }
 

--- a/src/rust/deploy/run.rs
+++ b/src/rust/deploy/run.rs
@@ -4,7 +4,7 @@ use delivery_core::{LoomMcpActionResult, LoomMcpDoneResult};
 use serde_json::json;
 
 use crate::{
-    active_operation::{acquire_operation, active_operation_result},
+    active_operation::{acquire_operation, active_operation_result, update_operation_phase},
     prepare::deploy_prepare_inner,
     up::deploy_up_inner,
     DeployToolInput,
@@ -25,6 +25,7 @@ pub fn deploy_run(input: DeployToolInput) -> LoomMcpActionResult {
             })
         }
     };
+    let _ = update_operation_phase(project_root, "preparing", "running");
     let prepare = deploy_prepare_inner(project_root, input.clone());
     match prepare {
         Ok(LoomMcpActionResult::Done(_)) => {}
@@ -42,6 +43,7 @@ pub fn deploy_run(input: DeployToolInput) -> LoomMcpActionResult {
             });
         }
     }
+    let _ = update_operation_phase(project_root, "building", "running");
     let result = deploy_up_inner(project_root, input);
     drop(guard);
     result

--- a/src/rust/deploy/runtime_state.rs
+++ b/src/rust/deploy/runtime_state.rs
@@ -7,7 +7,9 @@ use state::{
     store::{now_string, path_exists, write_json_atomic, StateResult},
 };
 
-use crate::{paths::deployment_paths, validate::DeploymentValidationResult};
+use crate::{
+    paths::deployment_paths, port_plan::primary_url, validate::DeploymentValidationResult,
+};
 
 pub fn write_success_state(
     project_root: &Path,
@@ -25,7 +27,8 @@ pub fn write_success_state(
             "specRef": to_project_relative(project_root, &paths.spec_file).ok(),
             "composePath": spec.files.compose_path,
             "running": true,
-            "url": spec.runtime.url,
+            "primaryUrl": primary_url(&spec.runtime),
+            "ports": spec.runtime.ports.clone(),
             "preview": validation.preview,
             "apiRoutes": validation.api_routes,
             "updatedAt": now_string()

--- a/src/rust/deploy/source_model.rs
+++ b/src/rust/deploy/source_model.rs
@@ -160,10 +160,12 @@ pub fn source_model_from_runtime_contract(
             .or(fallback_probe.package_manager)
             .or_else(|| default_package_manager(fallback_probe.kind)),
         has_lockfile: fallback_probe.has_lockfile,
-        framework: runtime
-            .runtime_kind
-            .clone()
-            .or_else(|| fallback_probe.framework.clone()),
+        framework: fallback_probe.framework.clone().or_else(|| {
+            runtime
+                .runtime_kind
+                .as_deref()
+                .and_then(normalized_framework_label)
+        }),
         runtime_version: fallback_probe.runtime_version.clone(),
         runtime_version_source: fallback_probe.runtime_version_source.clone(),
         build_command: runtime
@@ -294,6 +296,29 @@ fn runtime_kind_from_signals(signals: &[Option<&str>]) -> RuntimeKind {
         return RuntimeKind::Go;
     }
     RuntimeKind::Unknown
+}
+
+fn normalized_framework_label(value: &str) -> Option<String> {
+    let lower = value.to_ascii_lowercase();
+    if lower.contains("spring") {
+        Some("spring-boot".to_string())
+    } else if lower.contains("fastapi") {
+        Some("fastapi".to_string())
+    } else if lower.contains("django") {
+        Some("django".to_string())
+    } else if lower.contains("flask") {
+        Some("flask".to_string())
+    } else if lower.contains("aspnet") || lower.contains("asp.net") {
+        Some("aspnet".to_string())
+    } else if lower.contains("express") {
+        Some("express".to_string())
+    } else if lower.contains("next") {
+        Some("nextjs".to_string())
+    } else if lower.contains("vite") {
+        Some("vite".to_string())
+    } else {
+        None
+    }
 }
 
 fn package_manager_from_command(command: Option<&str>) -> Option<PackageManager> {

--- a/src/rust/deploy/source_model.rs
+++ b/src/rust/deploy/source_model.rs
@@ -132,11 +132,17 @@ pub fn source_model_from_runtime_contract(
         };
     }
 
-    let contract_kind = runtime_kind_from_signals(&[
-        runtime.api.as_ref().and_then(|api| api.kind.as_deref()),
-        runtime.runtime_kind.as_deref(),
-        runtime.start_command.as_deref(),
-    ]);
+    let contract_kind = if runtime_contract_declares_multi_root(runtime)
+        && fallback_probe.kind != RuntimeKind::Unknown
+    {
+        RuntimeKind::Unknown
+    } else {
+        runtime_kind_from_signals(&[
+            runtime.api.as_ref().and_then(|api| api.kind.as_deref()),
+            runtime.runtime_kind.as_deref(),
+            runtime.start_command.as_deref(),
+        ])
+    };
     let service = DeploymentSourceService {
         service_id: "app".to_string(),
         role: SourceServiceRole::App,
@@ -256,8 +262,60 @@ fn dependencies_from_runtime_or_probe(
 }
 
 fn command_is_usable(command: &str) -> bool {
-    let lower = command.to_ascii_lowercase();
-    !(lower.contains("service:") || lower.contains("web:"))
+    labeled_command_segments(command).is_empty()
+}
+
+pub fn runtime_contract_declares_multi_root(runtime: &DeploymentRuntimeContract) -> bool {
+    if runtime.deployment_shape == Some(DeploymentShape::FrontendAndBackend) {
+        return true;
+    }
+    let mut labels = Vec::new();
+    for command in [
+        runtime.build_command.as_deref(),
+        runtime.start_command.as_deref(),
+        runtime
+            .frontend
+            .as_ref()
+            .and_then(|endpoint| endpoint.build_command.as_deref()),
+        runtime
+            .api
+            .as_ref()
+            .and_then(|api| api.build_command.as_deref()),
+    ]
+    .into_iter()
+    .flatten()
+    {
+        labels.extend(labeled_command_segments(command));
+    }
+    labels.sort();
+    labels.dedup();
+    labels.len() >= 2
+}
+
+fn labeled_command_segments(command: &str) -> Vec<String> {
+    command
+        .split(';')
+        .flat_map(|part| part.split("&&"))
+        .flat_map(|part| part.split("||"))
+        .filter_map(|part| {
+            let trimmed = part.trim();
+            let (label, rest) = trimmed.split_once(':')?;
+            let label = label.trim();
+            if rest.trim().is_empty() || !is_command_segment_label(label) {
+                return None;
+            }
+            Some(label.to_ascii_lowercase())
+        })
+        .collect()
+}
+
+fn is_command_segment_label(value: &str) -> bool {
+    if value.is_empty() || value.contains(char::is_whitespace) {
+        return false;
+    }
+    value
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch == '-')
 }
 
 fn runtime_kind_from_signals(signals: &[Option<&str>]) -> RuntimeKind {

--- a/src/rust/deploy/up.rs
+++ b/src/rust/deploy/up.rs
@@ -1,6 +1,9 @@
 use std::{
+    fs::{File, OpenOptions},
+    io::{self, Read, Write},
     path::{Path, PathBuf},
-    process::Command,
+    process::{Command, Output, Stdio},
+    sync::{Arc, Mutex},
     thread,
     time::Duration,
 };
@@ -14,7 +17,7 @@ use state::{
 };
 
 use crate::{
-    active_operation::{acquire_operation, active_operation_result},
+    active_operation::{acquire_operation, active_operation_result, update_operation_phase},
     paths::deployment_paths,
     port_plan::primary_url,
     prepare::{deploy_prepare_inner, read_spec},
@@ -50,6 +53,7 @@ pub fn deploy_up(input: DeployToolInput) -> LoomMcpActionResult {
 pub fn deploy_up_inner(project_root: &Path, input: DeployToolInput) -> LoomMcpActionResult {
     let paths = deployment_paths(project_root);
     if !path_exists(&paths.spec_file) {
+        let _ = update_operation_phase(project_root, "preparing", "running");
         match deploy_prepare_inner(project_root, input.clone()) {
             Ok(LoomMcpActionResult::Done(_)) => {}
             Ok(result) => return result,
@@ -63,6 +67,7 @@ pub fn deploy_up_inner(project_root: &Path, input: DeployToolInput) -> LoomMcpAc
             }
         }
     }
+    let _ = update_operation_phase(project_root, "checking_docker", "running");
     let spec = match read_spec(project_root) {
         Ok(spec) => spec,
         Err(error) => {
@@ -77,6 +82,7 @@ pub fn deploy_up_inner(project_root: &Path, input: DeployToolInput) -> LoomMcpAc
     if let Err(result) = docker_available(project_root, &spec) {
         return result;
     }
+    let _ = update_operation_phase(project_root, "checking_compose", "running");
     let compose_file = match from_project_relative(project_root, &spec.files.compose_path) {
         Ok(file) => file,
         Err(error) => {
@@ -92,11 +98,20 @@ pub fn deploy_up_inner(project_root: &Path, input: DeployToolInput) -> LoomMcpAc
             .unwrap_or_else(|error| failed(project_root, error.to_string()));
         }
     };
-    let compose_config = Command::new("docker")
-        .args(["compose", "-f"])
-        .arg(&compose_file)
-        .args(["config", "--quiet"])
-        .output();
+    let compose_file_arg = compose_file.to_string_lossy().into_owned();
+    let compose_config_args = vec![
+        "compose".to_string(),
+        "-f".to_string(),
+        compose_file_arg.clone(),
+        "config".to_string(),
+        "--quiet".to_string(),
+    ];
+    let compose_config = run_logged_command(
+        project_root,
+        "checking_compose",
+        "docker",
+        &compose_config_args,
+    );
     match compose_config {
         Ok(output) if output.status.success() => {}
         Ok(output) => {
@@ -146,11 +161,16 @@ pub fn deploy_up_inner(project_root: &Path, input: DeployToolInput) -> LoomMcpAc
             .unwrap_or_else(|error| failed(project_root, error.to_string()));
         }
     }
-    let up = Command::new("docker")
-        .args(["compose", "-f"])
-        .arg(&compose_file)
-        .args(["up", "-d", "--build"])
-        .output();
+    let _ = update_operation_phase(project_root, "building", "running");
+    let up_args = vec![
+        "compose".to_string(),
+        "-f".to_string(),
+        compose_file_arg,
+        "up".to_string(),
+        "-d".to_string(),
+        "--build".to_string(),
+    ];
+    let up = run_logged_command(project_root, "building", "docker", &up_args);
     match up {
         Ok(output) if output.status.success() => {}
         Ok(output) => {
@@ -203,6 +223,7 @@ pub fn deploy_up_inner(project_root: &Path, input: DeployToolInput) -> LoomMcpAc
             .unwrap_or_else(|error| failed(project_root, error.to_string()));
         }
     }
+    let _ = update_operation_phase(project_root, "validating", "running");
     let validation = match wait_for_valid_deployment(project_root) {
         Ok(validation) => validation,
         Err(error) => {
@@ -261,6 +282,139 @@ pub fn deploy_up_inner(project_root: &Path, input: DeployToolInput) -> LoomMcpAc
         })),
         warnings: vec![],
     })
+}
+
+fn run_logged_command(
+    project_root: &Path,
+    phase: &str,
+    program: &str,
+    args: &[String],
+) -> io::Result<Output> {
+    let paths = deployment_paths(project_root);
+    let log_file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&paths.log_file)?;
+    let log = Arc::new(Mutex::new(log_file));
+    write_log_line(
+        &log,
+        &format!(
+            "\n[{}] phase={} command={}",
+            state::store::now_string(),
+            phase,
+            shell_display(program, args)
+        ),
+    )?;
+    let mut child = match Command::new(program)
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+    {
+        Ok(child) => child,
+        Err(error) => {
+            let _ = write_log_line(
+                &log,
+                &format!("[{}] spawn-error={}", state::store::now_string(), error),
+            );
+            return Err(error);
+        }
+    };
+
+    let stdout_buffer = Arc::new(Mutex::new(Vec::new()));
+    let stderr_buffer = Arc::new(Mutex::new(Vec::new()));
+    let stdout_handle = child
+        .stdout
+        .take()
+        .map(|stdout| tee_stream(stdout, "stdout", log.clone(), stdout_buffer.clone()));
+    let stderr_handle = child
+        .stderr
+        .take()
+        .map(|stderr| tee_stream(stderr, "stderr", log.clone(), stderr_buffer.clone()));
+    let status = child.wait()?;
+    if let Some(handle) = stdout_handle {
+        let _ = handle.join();
+    }
+    if let Some(handle) = stderr_handle {
+        let _ = handle.join();
+    }
+    write_log_line(
+        &log,
+        &format!(
+            "[{}] phase={} exit={}",
+            state::store::now_string(),
+            phase,
+            status.code().unwrap_or(-1)
+        ),
+    )?;
+    let stdout = stdout_buffer
+        .lock()
+        .map(|buffer| buffer.clone())
+        .unwrap_or_default();
+    let stderr = stderr_buffer
+        .lock()
+        .map(|buffer| buffer.clone())
+        .unwrap_or_default();
+    Ok(Output {
+        status,
+        stdout,
+        stderr,
+    })
+}
+
+fn tee_stream<R: Read + Send + 'static>(
+    mut reader: R,
+    label: &'static str,
+    log: Arc<Mutex<File>>,
+    buffer: Arc<Mutex<Vec<u8>>>,
+) -> thread::JoinHandle<()> {
+    thread::spawn(move || {
+        let mut chunk = [0_u8; 8192];
+        let mut wrote_label = false;
+        loop {
+            let Ok(read) = reader.read(&mut chunk) else {
+                break;
+            };
+            if read == 0 {
+                break;
+            }
+            if let Ok(mut output) = buffer.lock() {
+                output.extend_from_slice(&chunk[..read]);
+            }
+            if let Ok(mut file) = log.lock() {
+                if !wrote_label {
+                    let _ = writeln!(file, "\n[{label}]");
+                    wrote_label = true;
+                }
+                let _ = file.write_all(&chunk[..read]);
+                let _ = file.flush();
+            }
+        }
+    })
+}
+
+fn write_log_line(log: &Arc<Mutex<File>>, line: &str) -> io::Result<()> {
+    let mut file = log
+        .lock()
+        .map_err(|_| io::Error::other("deploy log mutex poisoned"))?;
+    writeln!(file, "{line}")?;
+    file.flush()
+}
+
+fn shell_display(program: &str, args: &[String]) -> String {
+    std::iter::once(program.to_string())
+        .chain(args.iter().map(|arg| {
+            if arg
+                .chars()
+                .any(|ch| ch.is_whitespace() || matches!(ch, '"' | '\'' | '$' | '\\'))
+            {
+                format!("'{}'", arg.replace('\'', "'\\''"))
+            } else {
+                arg.clone()
+            }
+        }))
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 fn should_fallback_to_generated(spec: &contracts::DeploymentSpec) -> bool {

--- a/src/rust/deploy/up.rs
+++ b/src/rust/deploy/up.rs
@@ -32,7 +32,7 @@ use crate::{
 const DEPLOY_STARTUP_VALIDATION_ATTEMPTS: usize = 24;
 const DEPLOY_STARTUP_VALIDATION_INTERVAL: Duration = Duration::from_millis(1500);
 const DEPLOY_OPERATION_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(15);
-const DEPLOY_OPERATION_HEARTBEAT_POLL_INTERVAL: Duration = Duration::from_millis(250);
+const DEPLOY_OPERATION_HEARTBEAT_POLL_INTERVAL: Duration = Duration::from_secs(3);
 
 pub fn deploy_up(input: DeployToolInput) -> LoomMcpActionResult {
     let project_root_buf = PathBuf::from(&input.project_root);

--- a/src/rust/deploy/up.rs
+++ b/src/rust/deploy/up.rs
@@ -16,6 +16,7 @@ use state::{
 use crate::{
     active_operation::{acquire_operation, active_operation_result},
     paths::deployment_paths,
+    port_plan::primary_url,
     prepare::{deploy_prepare_inner, read_spec},
     repair::write_repair_action,
     runtime_state::write_success_state,
@@ -252,7 +253,8 @@ pub fn deploy_up_inner(project_root: &Path, input: DeployToolInput) -> LoomMcpAc
         project_root: project_root.to_string_lossy().into_owned(),
         summary: "Deployment is running and validation passed.".to_string(),
         details: Some(json!({
-            "url": spec.runtime.url,
+            "primaryUrl": primary_url(&spec.runtime),
+            "ports": spec.runtime.ports,
             "preview": validation.preview,
             "apiRoutes": validation.api_routes,
             "stateRef": state_ref

--- a/src/rust/deploy/up.rs
+++ b/src/rust/deploy/up.rs
@@ -5,7 +5,7 @@ use std::{
     process::{Command, Output, Stdio},
     sync::{Arc, Mutex},
     thread,
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use contracts::{DeployProvider, DeploymentFailureKind, DeploymentProviderPolicy};
@@ -17,7 +17,9 @@ use state::{
 };
 
 use crate::{
-    active_operation::{acquire_operation, active_operation_result, update_operation_phase},
+    active_operation::{
+        acquire_operation, active_operation_result, touch_operation, update_operation_phase,
+    },
     paths::deployment_paths,
     port_plan::primary_url,
     prepare::{deploy_prepare_inner, read_spec},
@@ -29,6 +31,8 @@ use crate::{
 
 const DEPLOY_STARTUP_VALIDATION_ATTEMPTS: usize = 24;
 const DEPLOY_STARTUP_VALIDATION_INTERVAL: Duration = Duration::from_millis(1500);
+const DEPLOY_OPERATION_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(15);
+const DEPLOY_OPERATION_HEARTBEAT_POLL_INTERVAL: Duration = Duration::from_millis(250);
 
 pub fn deploy_up(input: DeployToolInput) -> LoomMcpActionResult {
     let project_root_buf = PathBuf::from(&input.project_root);
@@ -323,15 +327,32 @@ fn run_logged_command(
 
     let stdout_buffer = Arc::new(Mutex::new(Vec::new()));
     let stderr_buffer = Arc::new(Mutex::new(Vec::new()));
-    let stdout_handle = child
-        .stdout
-        .take()
-        .map(|stdout| tee_stream(stdout, "stdout", log.clone(), stdout_buffer.clone()));
-    let stderr_handle = child
-        .stderr
-        .take()
-        .map(|stderr| tee_stream(stderr, "stderr", log.clone(), stderr_buffer.clone()));
-    let status = child.wait()?;
+    let heartbeat = OperationHeartbeat::new(project_root);
+    let stdout_handle = child.stdout.take().map(|stdout| {
+        tee_stream(
+            stdout,
+            "stdout",
+            log.clone(),
+            stdout_buffer.clone(),
+            heartbeat.clone(),
+        )
+    });
+    let stderr_handle = child.stderr.take().map(|stderr| {
+        tee_stream(
+            stderr,
+            "stderr",
+            log.clone(),
+            stderr_buffer.clone(),
+            heartbeat.clone(),
+        )
+    });
+    let status = loop {
+        if let Some(status) = child.try_wait()? {
+            break status;
+        }
+        heartbeat.touch_if_due();
+        thread::sleep(heartbeat.poll_interval());
+    };
     if let Some(handle) = stdout_handle {
         let _ = handle.join();
     }
@@ -367,6 +388,7 @@ fn tee_stream<R: Read + Send + 'static>(
     label: &'static str,
     log: Arc<Mutex<File>>,
     buffer: Arc<Mutex<Vec<u8>>>,
+    heartbeat: OperationHeartbeat,
 ) -> thread::JoinHandle<()> {
     thread::spawn(move || {
         let mut chunk = [0_u8; 8192];
@@ -381,6 +403,7 @@ fn tee_stream<R: Read + Send + 'static>(
             if let Ok(mut output) = buffer.lock() {
                 output.extend_from_slice(&chunk[..read]);
             }
+            heartbeat.touch_if_due();
             if let Ok(mut file) = log.lock() {
                 if !wrote_label {
                     let _ = writeln!(file, "\n[{label}]");
@@ -391,6 +414,48 @@ fn tee_stream<R: Read + Send + 'static>(
             }
         }
     })
+}
+
+#[derive(Clone)]
+struct OperationHeartbeat {
+    project_root: PathBuf,
+    interval: Duration,
+    last_touch: Arc<Mutex<Instant>>,
+}
+
+impl OperationHeartbeat {
+    fn new(project_root: &Path) -> Self {
+        Self {
+            project_root: project_root.to_path_buf(),
+            interval: operation_heartbeat_interval(),
+            last_touch: Arc::new(Mutex::new(Instant::now())),
+        }
+    }
+
+    fn poll_interval(&self) -> Duration {
+        self.interval.min(DEPLOY_OPERATION_HEARTBEAT_POLL_INTERVAL)
+    }
+
+    fn touch_if_due(&self) {
+        let Ok(mut last_touch) = self.last_touch.lock() else {
+            return;
+        };
+        if last_touch.elapsed() < self.interval {
+            return;
+        }
+        if touch_operation(&self.project_root).is_ok() {
+            *last_touch = Instant::now();
+        }
+    }
+}
+
+fn operation_heartbeat_interval() -> Duration {
+    std::env::var("LOOM_DEPLOY_OPERATION_HEARTBEAT_MS")
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|value| *value >= 50)
+        .map(Duration::from_millis)
+        .unwrap_or(DEPLOY_OPERATION_HEARTBEAT_INTERVAL)
 }
 
 fn write_log_line(log: &Arc<Mutex<File>>, line: &str) -> io::Result<()> {

--- a/src/rust/deploy/validate.rs
+++ b/src/rust/deploy/validate.rs
@@ -1,7 +1,7 @@
 use std::{
     io::{Read, Write},
     net::TcpStream,
-    path::Path,
+    path::{Component, Path, PathBuf},
     time::Duration,
 };
 
@@ -128,10 +128,13 @@ pub fn validate_generated_assets(
         issues.push("compose file must include services.".to_string());
     }
     let compose_dir = compose_file.parent().unwrap_or(project_root);
-    for dockerfile in compose_dockerfile_paths(&compose) {
-        if !compose_dir.join(&dockerfile).exists() {
+    for build in compose_build_specs(&compose) {
+        let context_dir = normalize_path(compose_dir.join(&build.context));
+        let dockerfile_path = normalize_path(context_dir.join(&build.dockerfile));
+        if !dockerfile_path.exists() {
             issues.push(format!(
-                "compose dockerfile path {dockerfile} does not resolve from compose directory."
+                "compose dockerfile path {} does not resolve from build context {}.",
+                build.dockerfile, build.context
             ));
         }
     }
@@ -191,16 +194,68 @@ pub fn validate_generated_assets(
     Ok(issues)
 }
 
-fn compose_dockerfile_paths(compose: &str) -> Vec<String> {
-    compose
-        .lines()
-        .filter_map(|line| {
-            let trimmed = line.trim();
-            let value = trimmed.strip_prefix("dockerfile:")?.trim();
-            Some(value.trim_matches('"').trim_matches('\'').to_string())
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ComposeBuildSpec {
+    context: String,
+    dockerfile: String,
+}
+
+fn compose_build_specs(compose: &str) -> Vec<ComposeBuildSpec> {
+    let Ok(value) = serde_yaml::from_str::<serde_yaml::Value>(compose) else {
+        return Vec::new();
+    };
+    let Some(root) = value.as_mapping() else {
+        return Vec::new();
+    };
+    let Some(services) = yaml_get(root, "services").and_then(serde_yaml::Value::as_mapping) else {
+        return Vec::new();
+    };
+    services
+        .values()
+        .filter_map(|service| {
+            let service = service.as_mapping()?;
+            let build = yaml_get(service, "build")?;
+            if let Some(context) = build.as_str() {
+                return Some(ComposeBuildSpec {
+                    context: context.to_string(),
+                    dockerfile: "Dockerfile".to_string(),
+                });
+            }
+            let build = build.as_mapping()?;
+            Some(ComposeBuildSpec {
+                context: yaml_string_field(build, "context").unwrap_or_else(|| ".".to_string()),
+                dockerfile: yaml_string_field(build, "dockerfile")
+                    .unwrap_or_else(|| "Dockerfile".to_string()),
+            })
         })
-        .filter(|value| !value.is_empty())
         .collect()
+}
+
+fn yaml_get<'a>(mapping: &'a serde_yaml::Mapping, key: &str) -> Option<&'a serde_yaml::Value> {
+    mapping.get(&serde_yaml::Value::String(key.to_string()))
+}
+
+fn yaml_string_field(mapping: &serde_yaml::Mapping, key: &str) -> Option<String> {
+    yaml_get(mapping, key)
+        .and_then(serde_yaml::Value::as_str)
+        .map(str::to_string)
+        .filter(|value| !value.trim().is_empty())
+}
+
+fn normalize_path(path: PathBuf) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                let _ = normalized.pop();
+            }
+            Component::Prefix(_) | Component::RootDir | Component::Normal(_) => {
+                normalized.push(component.as_os_str());
+            }
+        }
+    }
+    normalized
 }
 
 fn probe_http(port: u16, path: &str, reject_html_fallback: bool) -> HttpProbeResult {

--- a/src/rust/deploy/validate.rs
+++ b/src/rust/deploy/validate.rs
@@ -14,7 +14,10 @@ use state::{
     store::{read_text, StateResult},
 };
 
-use crate::{prepare::read_spec, runtime_state::write_success_state, DeployToolInput};
+use crate::{
+    port_plan::primary_public_port, prepare::read_spec, runtime_state::write_success_state,
+    DeployToolInput,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -89,19 +92,26 @@ pub fn deploy_validate(input: DeployToolInput) -> LoomMcpActionResult {
 pub fn deploy_validate_inner(project_root: &Path) -> StateResult<DeploymentValidationResult> {
     let spec = read_spec(project_root)?;
     let asset_issues = validate_generated_assets(project_root, &spec)?;
+    let public_port = primary_public_port(&spec.runtime);
     let preview = spec
         .topology
         .validation
         .preview_paths
         .iter()
-        .map(|path| probe_http(spec.runtime.host_port, path, false))
+        .map(|path| match public_port {
+            Some(port) => probe_http(port, path, false),
+            None => missing_public_port_probe(path),
+        })
         .collect::<Vec<_>>();
     let api_routes = spec
         .topology
         .validation
         .api_paths
         .iter()
-        .map(|path| probe_http(spec.runtime.host_port, path, true))
+        .map(|path| match public_port {
+            Some(port) => probe_http(port, path, true),
+            None => missing_public_port_probe(path),
+        })
         .collect::<Vec<_>>();
     let compose_valid = asset_issues.iter().all(|issue| !issue.contains("compose"));
     let http_valid = preview.iter().all(|probe| probe.status == "ok")
@@ -115,6 +125,20 @@ pub fn deploy_validate_inner(project_root: &Path) -> StateResult<DeploymentValid
         api_routes,
         asset_issues,
     })
+}
+
+fn missing_public_port_probe(path: &str) -> HttpProbeResult {
+    HttpProbeResult {
+        path: if path.starts_with('/') {
+            path.to_string()
+        } else {
+            format!("/{path}")
+        },
+        status: "invalid".to_string(),
+        status_code: None,
+        error: Some("Deployment runtime has no public host port.".to_string()),
+        html_fallback: false,
+    }
 }
 
 pub fn validate_generated_assets(

--- a/tests/rust/deploy/deploy_workflow.rs
+++ b/tests/rust/deploy/deploy_workflow.rs
@@ -699,6 +699,7 @@ exit 0
 #[test]
 fn deploy_up_updates_active_operation_phase_and_streams_docker_logs() {
     let fixture = Fixture::new("deploy-active-operation-logs");
+    let _heartbeat_guard = EnvVarGuard::set("LOOM_DEPLOY_OPERATION_HEARTBEAT_MS", "100");
     fixture.write_runtime_delivery(json!({
         "status": "modified",
         "runtimeKind": "node",
@@ -751,10 +752,24 @@ exit 0
     let log_file = fixture.root.join(".loom/deployment/logs/local.log");
     let mut observed_building = false;
     let mut observed_log = false;
+    let mut first_building_updated_at: Option<u128> = None;
+    let mut observed_building_heartbeat = false;
     for _ in 0..40 {
         if active_file.exists() {
             if let Ok(active) = read_json::<Value>(&active_file) {
                 observed_building |= active["phase"] == "building";
+                if active["phase"] == "building" {
+                    if let Some(updated_at) = active["updatedAt"]
+                        .as_str()
+                        .and_then(|value| value.parse::<u128>().ok())
+                    {
+                        if let Some(first) = first_building_updated_at {
+                            observed_building_heartbeat |= updated_at > first;
+                        } else {
+                            first_building_updated_at = Some(updated_at);
+                        }
+                    }
+                }
             }
         }
         if log_file.exists() {
@@ -763,7 +778,7 @@ exit 0
                     && log.contains("build started");
             }
         }
-        if observed_building && observed_log {
+        if observed_building && observed_log && observed_building_heartbeat {
             break;
         }
         std::thread::sleep(std::time::Duration::from_millis(50));
@@ -772,6 +787,7 @@ exit 0
     let log = read_text(&log_file).expect("deploy log");
     assert!(observed_building, "{log}");
     assert!(observed_log, "{log}");
+    assert!(observed_building_heartbeat, "{log}");
     assert!(
         log.contains("phase=checking_compose command=docker compose"),
         "{log}"
@@ -2223,6 +2239,29 @@ struct PathEnvGuard {
 impl Drop for PathEnvGuard {
     fn drop(&mut self) {
         std::env::set_var("PATH", &self.previous);
+    }
+}
+
+struct EnvVarGuard {
+    key: &'static str,
+    previous: Option<String>,
+}
+
+impl EnvVarGuard {
+    fn set(key: &'static str, value: &str) -> Self {
+        let previous = std::env::var(key).ok();
+        std::env::set_var(key, value);
+        Self { key, previous }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        if let Some(previous) = &self.previous {
+            std::env::set_var(self.key, previous);
+        } else {
+            std::env::remove_var(self.key);
+        }
     }
 }
 

--- a/tests/rust/deploy/deploy_workflow.rs
+++ b/tests/rust/deploy/deploy_workflow.rs
@@ -12,8 +12,8 @@ use std::os::unix::fs::PermissionsExt;
 use contracts::{
     DeployProvider, DeploymentErrorWindow, DeploymentFailedContract, DeploymentFailureDiagnostic,
     DeploymentFailureKind, DeploymentFailureOwner, DeploymentFailureReport,
-    DeploymentProviderPolicy, DeploymentRepairAction, DeploymentRepairRoute, DeploymentShape,
-    DeploymentSpec, PackageManager, SourceModelSource,
+    DeploymentProviderPolicy, DeploymentRepairAction, DeploymentRepairRoute, DeploymentRuntimePort,
+    DeploymentShape, DeploymentSpec, PackageManager, SourceModelSource,
 };
 use delivery_core::{
     DeliveryIndex, DeliveryLifecycleStatus, DeliveryPhaseState, DeliveryStatusEntry,
@@ -73,6 +73,21 @@ fn prepare_uses_runtime_delivery_source_model_topology_without_single_node_colla
     assert!(serde_json::to_string(&spec.topology)
         .unwrap()
         .contains("\"publicPath\":\"/api\""));
+    let frontend_port = runtime_port(&spec, "frontend").expect("frontend runtime port");
+    assert_eq!(frontend_port.purpose, "preview");
+    assert_eq!(frontend_port.container_port, 80);
+    assert_eq!(frontend_port.preferred_host_port, Some(4173));
+    assert!(frontend_port.host_port.is_some(), "{frontend_port:?}");
+    assert!(!frontend_port.internal_only);
+    let backend_port = runtime_port(&spec, "backend").expect("backend runtime port");
+    assert_eq!(backend_port.purpose, "api");
+    assert_eq!(backend_port.container_port, 8080);
+    assert_eq!(backend_port.host_port, None);
+    assert!(backend_port.internal_only);
+    let postgres_port = runtime_port(&spec, "postgres").expect("postgres runtime port");
+    assert_eq!(postgres_port.purpose, "dependency");
+    assert_eq!(postgres_port.host_port, None);
+    assert!(postgres_port.internal_only);
 
     let nginx = read_text(
         &fixture
@@ -105,6 +120,10 @@ fn prepare_uses_runtime_delivery_source_model_topology_without_single_node_colla
     assert!(compose.contains("  postgres:"));
     assert!(compose.contains("      - backend"));
     assert!(compose.contains("      - postgres"));
+    assert!(compose.contains("  frontend:\n    build:"), "{compose}");
+    assert!(compose.contains("    ports:\n"), "{compose}");
+    let backend_block = compose_service_block(&compose, "backend").expect("backend compose block");
+    assert!(!backend_block.contains("ports:"), "{backend_block}");
 }
 
 #[test]
@@ -235,6 +254,8 @@ fn deploy_prepare_returns_refs_and_compact_summaries_without_full_spec_sections(
     assert!(details["sourceModelSummary"].is_object(), "{value:#}");
     assert!(details["topologySummary"].is_object(), "{value:#}");
     assert!(details["generatedFileRefs"].is_array(), "{value:#}");
+    assert!(details["primaryUrl"].as_str().is_some(), "{value:#}");
+    assert!(details["ports"].as_array().is_some(), "{value:#}");
     assert!(
         details.get("sourceModel").is_none()
             && details.get("topology").is_none()
@@ -242,6 +263,43 @@ fn deploy_prepare_returns_refs_and_compact_summaries_without_full_spec_sections(
         "deploy prepare must not inline full deploy spec sections: {value:#}"
     );
     assert_forbidden_cli_fields_absent(&value);
+}
+
+#[test]
+fn deploy_prepare_auto_resolves_occupied_preferred_host_port() {
+    let fixture = Fixture::new("deploy-port-fallback");
+    let occupied = TcpListener::bind(("127.0.0.1", 0)).expect("bind occupied test port");
+    let preferred_port = occupied.local_addr().expect("occupied test addr").port();
+    fixture.write_runtime_delivery(json!({
+        "status": "modified",
+        "runtimeKind": "node",
+        "deploymentShape": "single-service",
+        "httpProbes": { "previewPath": "/" },
+        "start": { "command": "npm run start", "port": preferred_port }
+    }));
+    fixture.write_text(
+        "package.json",
+        r#"{"scripts":{"build":"vite","start":"vite --host 0.0.0.0"}}"#,
+    );
+
+    let result = deploy_prepare(DeployToolInput {
+        project_root: fixture.root_str(),
+        app_path: None,
+        healthcheck: None,
+        provider_policy: None,
+    });
+    let value = serde_json::to_value(result).expect("prepare json");
+    assert_eq!(value["state"], "done", "{value:#}");
+
+    let spec = fixture.read_spec();
+    let preview = runtime_port(&spec, "app").expect("app runtime port");
+    assert_eq!(preview.preferred_host_port, Some(preferred_port));
+    assert_ne!(preview.host_port, Some(preferred_port));
+    assert!(preview.host_port.is_some());
+    assert_ne!(
+        runtime_primary_url(&spec),
+        format!("http://localhost:{preferred_port}")
+    );
 }
 
 #[test]
@@ -285,8 +343,14 @@ fn deploy_prepare_prefers_existing_compose_without_inlining_or_editing_it() {
     let spec = fixture.read_spec();
     assert_eq!(spec.provider, DeployProvider::ComposeExisting);
     assert_eq!(spec.files.compose_path, "compose.yaml");
-    assert_eq!(spec.runtime.host_port, 5555);
-    assert_eq!(spec.runtime.container_port, 8080);
+    let preview_port = spec
+        .runtime
+        .ports
+        .iter()
+        .find(|port| port.purpose == "preview")
+        .expect("preview port");
+    assert_eq!(preview_port.host_port, Some(5555));
+    assert_eq!(preview_port.container_port, 8080);
     assert!(!fixture
         .root
         .join(".loom/deployment/specs/generated/compose.yaml")
@@ -518,12 +582,13 @@ exit 0
 #[test]
 fn deploy_validate_success_writes_state_and_clears_failure_artifacts() {
     let fixture = Fixture::new("deploy-validate-clears-failure");
+    let preferred_port = free_test_port();
     fixture.write_runtime_delivery(json!({
         "status": "modified",
         "runtimeKind": "node",
         "deploymentShape": "single-service",
         "httpProbes": { "previewPath": "/" },
-        "start": { "port": 8080 }
+        "start": { "port": preferred_port }
     }));
     fixture.write_text(
         "package.json",
@@ -539,7 +604,7 @@ fn deploy_validate_success_writes_state_and_clears_failure_artifacts() {
     assert_eq!(value["state"], "done", "{value:#}");
     let spec: DeploymentSpec =
         read_json(&fixture.root.join(".loom/deployment/specs/local.json")).expect("spec");
-    let _server = spawn_one_shot_http_server(spec.runtime.host_port);
+    let _server = spawn_one_shot_http_server(runtime_public_port(&spec));
     fixture.write_text(".loom/deployment/state/latest-failure.json", "{}\n");
     fixture.write_text(".loom/deployment/state/repair-action.json", "{}\n");
 
@@ -1976,6 +2041,67 @@ fn spawn_one_shot_http_server(port: u16) -> thread::JoinHandle<()> {
             let _ = stream.write_all(response.as_bytes());
         }
     })
+}
+
+fn free_test_port() -> u16 {
+    TcpListener::bind(("127.0.0.1", 0))
+        .expect("bind dynamic test port")
+        .local_addr()
+        .expect("test port addr")
+        .port()
+}
+
+fn runtime_port<'a>(
+    spec: &'a DeploymentSpec,
+    service_id: &str,
+) -> Option<&'a DeploymentRuntimePort> {
+    spec.runtime
+        .ports
+        .iter()
+        .find(|port| port.service_id == service_id)
+}
+
+fn runtime_public_port(spec: &DeploymentSpec) -> u16 {
+    spec.runtime
+        .ports
+        .iter()
+        .find(|port| port.service_id == spec.runtime.primary_service_id && !port.internal_only)
+        .and_then(|port| port.host_port)
+        .or_else(|| {
+            spec.runtime
+                .ports
+                .iter()
+                .find(|port| !port.internal_only)
+                .and_then(|port| port.host_port)
+        })
+        .expect("public runtime host port")
+}
+
+fn runtime_primary_url(spec: &DeploymentSpec) -> String {
+    spec.runtime
+        .ports
+        .iter()
+        .find(|port| port.service_id == spec.runtime.primary_service_id && !port.internal_only)
+        .and_then(|port| port.url.clone())
+        .or_else(|| {
+            spec.runtime
+                .ports
+                .iter()
+                .find(|port| !port.internal_only)
+                .and_then(|port| port.url.clone())
+        })
+        .expect("runtime primary url")
+}
+
+fn compose_service_block<'a>(compose: &'a str, service_id: &str) -> Option<&'a str> {
+    let marker = format!("  {service_id}:");
+    let start = compose.find(&marker)?;
+    let rest = &compose[start + marker.len()..];
+    let end = rest
+        .find("\n  ")
+        .map(|index| start + marker.len() + index)
+        .unwrap_or(compose.len());
+    Some(&compose[start..end])
 }
 
 fn test_env_lock() -> &'static Mutex<()> {

--- a/tests/rust/deploy/deploy_workflow.rs
+++ b/tests/rust/deploy/deploy_workflow.rs
@@ -248,6 +248,101 @@ fn prepare_uses_repository_code_evidence_for_gradle_vite_workspace() {
 }
 
 #[test]
+fn prepare_promotes_composite_runtime_above_preview_app_path() {
+    let fixture = Fixture::new("deploy-composite-app-path");
+    fixture.write_runtime_delivery(json!({
+        "status": "modified",
+        "runtimeKind": "spring boot service with vite web",
+        "deploymentShape": "single-service",
+        "build": { "command": "service: ./gradlew test && ./gradlew bootJar; web: npm run build" },
+        "start": { "command": "service: ./gradlew bootRun; web: npm run dev", "port": 8080 },
+        "httpProbes": { "previewPath": "/" }
+    }));
+    fixture.write_text(
+        "service/build.gradle",
+        "plugins { id 'org.springframework.boot' version '3.5.6' }\n",
+    );
+    fixture.write_text("service/gradlew", "#!/bin/sh\n");
+    fixture.write_text(
+        "web/package.json",
+        r#"{"scripts":{"build":"vite"},"dependencies":{"react":"latest"}}"#,
+    );
+    fixture.write_text("web/package-lock.json", "{}\n");
+    fixture.write_text("web/vite.config.ts", "export default {}\n");
+
+    let result = deploy_prepare(DeployToolInput {
+        project_root: fixture.root_str(),
+        app_path: Some("web".to_string()),
+        healthcheck: None,
+        provider_policy: None,
+    });
+    let value = serde_json::to_value(result).expect("result json");
+    assert_eq!(value["state"], "done", "{value:#}");
+
+    let spec: DeploymentSpec = read_json(&fixture.root.join(".loom/deployment/specs/local.json"))
+        .expect("deployment spec");
+    let service = spec
+        .source_model
+        .services
+        .iter()
+        .find(|service| service.service_id == "app")
+        .expect("app service");
+    assert_eq!(spec.source_model.build_context_path, "../../../..");
+    assert_eq!(service.runtime_kind, contracts::RuntimeKind::Java);
+    assert_eq!(service.package_manager, Some(PackageManager::Gradle));
+    assert_eq!(service.framework.as_deref(), Some("spring-boot"));
+    assert_eq!(
+        service.workspace_package_json_paths,
+        vec!["web/package.json"]
+    );
+    assert_eq!(service.output_directory.as_deref(), Some("web/dist"));
+    assert_eq!(
+        service.build_command.as_deref(),
+        Some("cd service && chmod +x ./gradlew && ./gradlew bootJar --no-daemon")
+    );
+    assert!(!serde_json::to_string(&spec.source_model)
+        .unwrap()
+        .contains("npm run preview"));
+
+    let compose = read_text(
+        &fixture
+            .root
+            .join(".loom/deployment/specs/generated/compose.yaml"),
+    )
+    .expect("compose");
+    assert!(compose.contains("context: ../../../.."), "{compose}");
+
+    let dockerfile = read_text(
+        &fixture
+            .root
+            .join(".loom/deployment/specs/generated/Dockerfile.app"),
+    )
+    .expect("dockerfile");
+    assert!(
+        dockerfile.contains("FROM node:22-bookworm-slim AS web-builder"),
+        "{dockerfile}"
+    );
+    assert!(
+        dockerfile.contains("FROM eclipse-temurin:21-jdk AS service-builder"),
+        "{dockerfile}"
+    );
+    assert!(
+        dockerfile.contains("COPY --from=service-builder /tmp/app.jar /app/app.jar"),
+        "{dockerfile}"
+    );
+    assert!(!dockerfile.contains("FROM nginx"), "{dockerfile}");
+
+    let evidence: Value = read_json(
+        &fixture
+            .root
+            .join(".loom/deployment/evidence/latest-code-evidence.json"),
+    )
+    .expect("code evidence");
+    assert_eq!(evidence["projectRoot"], fixture.root_str());
+    assert_eq!(evidence["repositoryShape"], "multi_application");
+}
+
+#[test]
 fn deploy_prepare_returns_refs_and_compact_summaries_without_full_spec_sections() {
     let fixture = Fixture::new("deploy-prepare-compact-output");
     fixture.write_runtime_delivery(runtime_delivery());

--- a/tests/rust/deploy/deploy_workflow.rs
+++ b/tests/rust/deploy/deploy_workflow.rs
@@ -95,8 +95,12 @@ fn prepare_uses_runtime_delivery_source_model_topology_without_single_node_colla
     )
     .expect("compose");
     assert!(compose.contains("  frontend:"));
-    assert!(compose.contains("      dockerfile: Dockerfile.frontend"));
-    assert!(compose.contains("      dockerfile: Dockerfile.backend"));
+    assert!(
+        compose.contains("      dockerfile: .loom/deployment/specs/generated/Dockerfile.frontend")
+    );
+    assert!(
+        compose.contains("      dockerfile: .loom/deployment/specs/generated/Dockerfile.backend")
+    );
     assert!(compose.contains("  backend:"));
     assert!(compose.contains("  postgres:"));
     assert!(compose.contains("      - backend"));
@@ -167,11 +171,11 @@ fn prepare_uses_repository_code_evidence_for_gradle_vite_workspace() {
     )
     .expect("compose");
     assert!(compose.contains("context: ../../../.."), "{compose}");
-    assert!(compose.contains("dockerfile: Dockerfile.app"), "{compose}");
     assert!(
-        !compose.contains("dockerfile: .loom/deployment/specs/generated/Dockerfile.app"),
+        compose.contains("dockerfile: .loom/deployment/specs/generated/Dockerfile.app"),
         "{compose}"
     );
+    assert!(!compose.contains("additional_contexts"), "{compose}");
 
     let dockerfile = read_text(
         &fixture
@@ -192,6 +196,10 @@ fn prepare_uses_repository_code_evidence_for_gradle_vite_workspace() {
         "{dockerfile}"
     );
     assert!(!dockerfile.contains("./mvnw"), "{dockerfile}");
+    assert!(fixture
+        .root
+        .join(".loom/deployment/specs/generated/Dockerfile.app.dockerignore")
+        .exists());
 
     let evidence: Value = read_json(
         &fixture
@@ -584,12 +592,15 @@ fn deploy_validate_flags_compose_dockerfile_paths_that_do_not_resolve() {
         .root
         .join(".loom/deployment/specs/generated/compose.yaml");
     let compose = read_text(&compose_path).expect("compose");
-    assert!(compose.contains("dockerfile: Dockerfile.app"), "{compose}");
+    assert!(
+        compose.contains("dockerfile: .loom/deployment/specs/generated/Dockerfile.app"),
+        "{compose}"
+    );
     std::fs::write(
         &compose_path,
         compose.replace(
-            "dockerfile: Dockerfile.app",
             "dockerfile: .loom/deployment/specs/generated/Dockerfile.app",
+            "dockerfile: Dockerfile.app",
         ),
     )
     .expect("write bad compose");

--- a/tests/rust/deploy/deploy_workflow.rs
+++ b/tests/rust/deploy/deploy_workflow.rs
@@ -109,6 +109,10 @@ fn prepare_uses_runtime_delivery_source_model_topology_without_single_node_colla
             .join(".loom/deployment/specs/generated/compose.yaml"),
     )
     .expect("compose");
+    assert!(
+        compose.starts_with(&format!("name: {}\nservices:\n", spec.service_name)),
+        "{compose}"
+    );
     assert!(compose.contains("  frontend:"));
     assert!(
         compose.contains("      dockerfile: .loom/deployment/specs/generated/Dockerfile.frontend")
@@ -172,6 +176,7 @@ fn prepare_uses_repository_code_evidence_for_gradle_vite_workspace() {
         .expect("app service");
     assert_eq!(spec.source_model.source, SourceModelSource::RuntimeContract);
     assert_eq!(service.package_manager, Some(PackageManager::Gradle));
+    assert_eq!(service.framework.as_deref(), Some("spring-boot"));
     assert_eq!(
         service.build_command.as_deref(),
         Some("cd service && chmod +x ./gradlew && ./gradlew bootJar --no-daemon")
@@ -219,6 +224,16 @@ fn prepare_uses_repository_code_evidence_for_gradle_vite_workspace() {
         .root
         .join(".loom/deployment/specs/generated/Dockerfile.app.dockerignore")
         .exists());
+    assert_eq!(
+        spec.files.dockerignore_paths["app"],
+        ".loom/deployment/specs/generated/Dockerfile.app.dockerignore"
+    );
+    let spec_json: Value =
+        read_json(&fixture.root.join(".loom/deployment/specs/local.json")).expect("spec json");
+    assert!(
+        spec_json["files"].get("dockerignorePath").is_none(),
+        "{spec_json:#}"
+    );
 
     let evidence: Value = read_json(
         &fixture
@@ -390,10 +405,16 @@ fn deploy_prepare_reuses_existing_dockerfile_and_generates_only_wrapper_assets()
         .unwrap()
         .iter()
         .any(|item| item == ".loom/deployment/specs/generated/compose.yaml"));
+    assert!(!value["details"]["generatedFileRefs"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|item| item == ".loom/deployment/specs/generated/Dockerfile.app.dockerignore"));
 
     let spec = fixture.read_spec();
     assert_eq!(spec.provider, DeployProvider::DockerfileExisting);
     assert_eq!(spec.files.dockerfile_paths["app"], "Dockerfile");
+    assert!(spec.files.dockerignore_paths.is_empty());
     assert!(fixture
         .root
         .join(".loom/deployment/specs/generated/compose.yaml")
@@ -577,6 +598,90 @@ exit 0
         .unwrap_or(true));
     assert_eq!(repair["protectedFiles"], json!(["compose.yaml"]));
     assert_eq!(value["state"], "blocked", "{value:#}");
+}
+
+#[cfg(unix)]
+#[test]
+fn deploy_up_updates_active_operation_phase_and_streams_docker_logs() {
+    let fixture = Fixture::new("deploy-active-operation-logs");
+    fixture.write_runtime_delivery(json!({
+        "status": "modified",
+        "runtimeKind": "node",
+        "deploymentShape": "single-service",
+        "start": { "command": "npm run start", "port": 8080 },
+        "httpProbes": { "previewPath": "/" }
+    }));
+    fixture.write_text(
+        "package.json",
+        r#"{"scripts":{"build":"vite","start":"vite --host 0.0.0.0"}}"#,
+    );
+    fixture.write_mock_docker(
+        r##"#!/bin/sh
+if [ "$1" = "--version" ]; then echo "Docker version 25.0.0"; exit 0; fi
+if [ "$1" = "compose" ] && [ "$4" = "config" ]; then
+  echo "config ok"
+  exit 0
+fi
+if [ "$1" = "compose" ] && [ "$4" = "up" ]; then
+  echo "build started"
+  sleep 1
+  echo "build done"
+  exit 0
+fi
+if [ "$1" = "compose" ] && [ "$4" = "logs" ]; then
+  echo "app did not become reachable"
+  exit 0
+fi
+exit 0
+"##,
+    );
+    let _path_guard = fixture.prepend_mock_bin_to_path();
+    let root = fixture.root_str();
+    let handle = thread::spawn(move || {
+        deploy_up(DeployToolInput {
+            project_root: root,
+            app_path: None,
+            healthcheck: None,
+            provider_policy: Some(DeploymentProviderPolicy {
+                provider: Some(DeployProvider::Generated),
+                reuse_existing: false,
+                force_generate: true,
+            }),
+        })
+    });
+
+    let active_file = fixture
+        .root
+        .join(".loom/deployment/state/active-operation.json");
+    let log_file = fixture.root.join(".loom/deployment/logs/local.log");
+    let mut observed_building = false;
+    let mut observed_log = false;
+    for _ in 0..40 {
+        if active_file.exists() {
+            if let Ok(active) = read_json::<Value>(&active_file) {
+                observed_building |= active["phase"] == "building";
+            }
+        }
+        if log_file.exists() {
+            if let Ok(log) = read_text(&log_file) {
+                observed_log |= log.contains("phase=building command=docker compose")
+                    && log.contains("build started");
+            }
+        }
+        if observed_building && observed_log {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    let _ = handle.join().expect("deploy up thread");
+    let log = read_text(&log_file).expect("deploy log");
+    assert!(observed_building, "{log}");
+    assert!(observed_log, "{log}");
+    assert!(
+        log.contains("phase=checking_compose command=docker compose"),
+        "{log}"
+    );
+    assert!(log.contains("config ok"), "{log}");
 }
 
 #[test]

--- a/tests/rust/setup/setup_workflow.rs
+++ b/tests/rust/setup/setup_workflow.rs
@@ -403,7 +403,7 @@ fn release_workflow_uploads_installers_packages_and_checksums() {
     assert!(workflow.contains("install.ps1.sha256"));
     assert!(workflow.contains(".tar.gz.sha256"));
     assert!(workflow.contains(".zip.sha256"));
-    assert!(workflow.contains("softprops/action-gh-release@v2"));
+    assert!(workflow.contains("softprops/action-gh-release@v3"));
     assert!(workflow.contains("make_latest: true"));
 }
 


### PR DESCRIPTION
## Summary

This PR prepares Loom `v0.2.1` by updating the release workflow for Node 24-compatible GitHub Actions and improving the MCP deploy workflow for multi-service projects.

## Changes

- Updated release workflow actions to newer Node 24-compatible versions.
- Bumped Loom version to `0.2.1` across installers, package metadata, and Rust workspace metadata.
- Improved deploy generation:
  - multi-port runtime planning
  - Compose project name generation
  - Dockerfile/build-context path alignment
  - per-service `.dockerignore` handling
  - composite service + web deployment root selection
- Improved deploy observability:
  - active operation phase/log updates
  - heartbeat refresh during long-running deploy commands
  - 3s polling interval with automatic cleanup after command completion
- Updated Rust tests for release workflow and deploy behavior.

## Verification

- `cargo fmt --all -- --check`
- `cargo test --manifest-path src/rust/Cargo.toml`
- `python3 -m pytest tests/python`
- `./install.sh --agent all --print-plan`
- `cargo metadata --manifest-path src/rust/Cargo.toml --format-version 1 --no-deps`

## Notes

Target release version: `v0.2.1`