### PR TITLE
docs: remove Godot README navigation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@
     ·
     <a href="https://zonodqioyxil6r3k.public.blob.vercel-storage.com/Loomline-v0.pdf">Technical Report</a>
     ·
-    <a href="./docs/godot.md">Godot</a>
-    ·
     <a href="./docs/use-cases.md">Use Cases</a>
     ·
     <a href="#quick-start">Quick Start</a>


### PR DESCRIPTION
Remove the redundant Godot link from the README top navigation. The Godot documentation remains available in the README content.