### PR TITLE
chore(release): prepare v0.2.8

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -6,7 +6,7 @@ param(
   [string]$Agent,
 
   [Alias("version")]
-  [string]$Version = "0.2.7",
+  [string]$Version = "0.2.8",
 
   [Alias("baseUrl")]
   [string]$BaseUrl = "https://github.com/valkor-ai/loom/releases/latest/download",

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 set -eu
 
 AGENT=""
-VERSION="0.2.7"
+VERSION="0.2.8"
 VERSION_FROM_ARGS=0
 BASE_URL="https://github.com/valkor-ai/loom/releases/latest/download"
 BASE_URL_FROM_ARGS=0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loom",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "A delivery layer for coding agents that turns product requests into planned, verified, deployable software changes.",
   "license": "Apache-2.0",
   "private": true,

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "loom",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "A Claude Code adapter for Loom that routes /loom commands through the Loom MCP server.",
   "hooks": "./hooks/hooks.json",
   "author": {

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "loom",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Mandatory Codex adapter for Loom: route every explicit @loom delivery request through Loom MCP before any repository work.",
   "author": {
     "name": "Loom"

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "algorithm-client"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "serde_json",
 ]
@@ -61,7 +61,7 @@ dependencies = [
 
 [[package]]
 name = "architecture"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "contracts",
  "delivery-core",
@@ -120,7 +120,7 @@ dependencies = [
 
 [[package]]
 name = "brainstorm"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "algorithm-client",
  "contracts",
@@ -228,7 +228,7 @@ checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "contracts"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "delivery-core",
  "schemars",
@@ -327,7 +327,7 @@ checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
 
 [[package]]
 name = "delivery-core"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "schemars",
  "serde",
@@ -338,7 +338,7 @@ dependencies = [
 
 [[package]]
 name = "deploy"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "contracts",
  "delivery-core",
@@ -430,7 +430,7 @@ dependencies = [
 
 [[package]]
 name = "execution"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "architecture",
  "brainstorm",
@@ -666,7 +666,7 @@ dependencies = [
 
 [[package]]
 name = "knowledge"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "algorithm-client",
  "chrono",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-server"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "anyhow",
  "architecture",
@@ -883,7 +883,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "planning"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "brainstorm",
  "contracts",
@@ -1168,7 +1168,7 @@ dependencies = [
 
 [[package]]
 name = "setup"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "chrono",
  "delivery-core",
@@ -1232,7 +1232,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "state"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "delivery-core",
  "schemars",
@@ -1487,7 +1487,7 @@ checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "verification"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "anyhow",
  "delivery-core",
@@ -1655,7 +1655,7 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "workflow"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "architecture",
  "brainstorm",

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.7"
+version = "0.2.8"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/valkor-ai/loom"

--- a/src/rust/core/route_action.rs
+++ b/src/rust/core/route_action.rs
@@ -74,11 +74,10 @@ impl RouteActionKind {
             | Self::ArchitectureArtifactContract
             | Self::TaskplanGeneration
             | Self::ContinueExecution => Some(8),
-            Self::Review
-            | Self::ExecutionRepair
-            | Self::NeedsUserDecision
-            | Self::ManualReview
-            | Self::VsefmOnboarding
+            Self::Review | Self::ExecutionRepair | Self::NeedsUserDecision | Self::ManualReview => {
+                Some(9)
+            }
+            Self::VsefmOnboarding
             | Self::VsefmVerification
             | Self::VsefmResultGate
             | Self::VsefmRepair => Some(10),

--- a/tests/rust/core/route_action_mapping.rs
+++ b/tests/rust/core/route_action_mapping.rs
@@ -41,6 +41,7 @@ fn route_action_target_batches_are_stable() {
         Some(8)
     );
     assert_eq!(RouteActionKind::Review.target_batch(), Some(9));
+    assert_eq!(RouteActionKind::VsefmVerification.target_batch(), Some(10));
     assert_eq!(RouteActionKind::TaskResultRepair.target_batch(), Some(5));
     assert_eq!(RouteActionKind::Done.target_batch(), None);
 }


### PR DESCRIPTION
## Summary

This follow-up PR completes the `v0.2.8` release preparation after the V-SEFM feature changes were merged through PR #74.

It synchronizes all runtime, installer, and agent plugin version declarations to `0.2.8`. It also fixes a route-batch mapping issue found during full release validation.

## Changes

### Version synchronization

Update the release version from `0.2.7` to `0.2.8` in:

- Root `package.json`.
- Rust workspace metadata.
- Cargo lockfile workspace packages.
- macOS/Linux installer defaults.
- Windows installer defaults.
- Codex plugin manifest.
- Claude Code plugin manifest.

This ensures local builds, release archives, installation scripts, and agent plugins all report and enforce the same version.

### Route batch correction

Separate the existing Review workflow from the newly introduced V-SEFM workflow:

- Keep `Review`, `ExecutionRepair`, `NeedsUserDecision`, and `ManualReview` in batch 9.
- Keep `VsefmOnboarding`, `VsefmVerification`, `VsefmResultGate`, and `VsefmRepair` in batch 10.

Previously, adding V-SEFM routing accidentally moved the existing Review actions into batch 10. The corrected mapping preserves the established Review boundary while assigning V-SEFM its own batch.

### Regression coverage

Extend the route-action mapping test to verify both sides of the boundary:

- Review actions resolve to batch 9.
- V-SEFM verification resolves to batch 10.

## Release impact

After this PR is merged, the remote `main` branch will contain the complete `0.2.8` version metadata and can be safely tagged as `v0.2.8`.

Without this PR, `main` still identifies itself as `0.2.7`, even though the V-SEFM functionality from PR #74 is already present.

## Verification

The complete release validation passed:

- `npm run rust:test`
  - 557 Rust unit, integration, workflow, and contract tests passed.
- `npm run python:test`
  - 7 Python tests passed.
- `cargo fmt --manifest-path src/rust/Cargo.toml --all --check`
- `cargo build --manifest-path src/rust/Cargo.toml -p mcp-server -p setup`
- `cargo test --manifest-path src/rust/Cargo.toml -p delivery-core --test route_action_mapping`
- `git diff --check`

## Checklist

- [x] Package version updated to `0.2.8`.
- [x] Rust workspace and lockfile versions synchronized.
- [x] Installer defaults updated.
- [x] Agent plugin manifest versions updated.
- [x] Review and V-SEFM route batches separated.
- [x] Regression coverage added.
- [x] Complete release validation passed.