### PR TITLE
feat(verification): add delivery verification history

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## Summary
+
+<!-- What changed, and why? -->
+
+## Verification
+
+<!-- List the checks you ran and their result. -->
+
+- [ ] Tests or checks were run where applicable.
+- [ ] Documentation was updated where behavior or setup changed.
+- [ ] No generated `.loom/` state or secrets are included.
+
+## Related Issue
+
+<!-- Closes #123, or write N/A. -->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: /src/rust
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: pip
+    directory: /src/python/algorithms
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,8 @@ jobs:
       - name: Check workspace
         run: cargo check --manifest-path src/rust/Cargo.toml --workspace
 
-      - name: Test workspace
-        run: cargo test --manifest-path src/rust/Cargo.toml --workspace --exclude release-tests
+      - name: Test workspace libraries
+        run: cargo test --manifest-path src/rust/Cargo.toml --workspace --lib
 
       - name: Build release binaries
         run: cargo build --release --manifest-path src/rust/Cargo.toml -p mcp-server -p setup

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,16 @@ jobs:
         with:
           components: rustfmt
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: src/python/algorithms/pyproject.toml
+
+      - name: Install algorithm dependencies
+        run: python -m pip install --upgrade pip -e src/python/algorithms
+
       - name: Check formatting
         run: cargo fmt --manifest-path src/rust/Cargo.toml --all --check
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,58 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  rust:
+    name: Rust format, check, test, and build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: Check formatting
+        run: cargo fmt --manifest-path src/rust/Cargo.toml --all --check
+
+      - name: Check workspace
+        run: cargo check --manifest-path src/rust/Cargo.toml --workspace
+
+      - name: Test workspace
+        run: cargo test --manifest-path src/rust/Cargo.toml --workspace --exclude release-tests
+
+      - name: Build release binaries
+        run: cargo build --release --manifest-path src/rust/Cargo.toml -p mcp-server -p setup
+
+  python:
+    name: Python algorithm tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: src/python/algorithms/pyproject.toml
+
+      - name: Install dependencies
+        run: python -m pip install --upgrade pip pytest -e src/python/algorithms
+
+      - name: Test algorithm worker
+        run: python -m pytest tests/python

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ coverage/
 # Loomline local project state
 .loomline/
 
+# Loom runtime state
+.loom/
+
 # Local environment and editor files
 .env
 .env.*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ For Rust changes, run the relevant checks before opening a PR:
 ```bash
 cargo fmt --manifest-path src/rust/Cargo.toml --all --check
 cargo check --manifest-path src/rust/Cargo.toml --workspace
-cargo test --manifest-path src/rust/Cargo.toml --workspace --exclude release-tests
+cargo test --manifest-path src/rust/Cargo.toml --workspace --lib
 cargo build --manifest-path src/rust/Cargo.toml -p mcp-server -p setup
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,17 +23,29 @@ Please keep pull requests focused and easy to review:
 - Use Conventional Commit messages such as `feat: add new capability`, `fix: correct broken behavior`, or `docs: update README`.
 - Include a short summary and testing notes in the PR description.
 - Keep unrelated refactors out of the PR unless they are required for the change.
+- Resolve review conversations before merging.
+- Squash focused changes into one clear commit when merging.
 
 ## Local Checks
 
-For code changes, run the relevant checks before opening a PR:
+For Rust changes, run the relevant checks before opening a PR:
 
 ```bash
-npm run build
+cargo fmt --manifest-path src/rust/Cargo.toml --all --check
+cargo check --manifest-path src/rust/Cargo.toml --workspace
+cargo test --manifest-path src/rust/Cargo.toml --workspace --exclude release-tests
+cargo build --manifest-path src/rust/Cargo.toml -p mcp-server -p setup
 ```
 
-For documentation-only changes, a visual review of the rendered Markdown is usually enough.
+For changes to the Python algorithm worker, install its local dependencies and run:
+
+```bash
+python3 -m pip install -e src/python/algorithms pytest
+npm run python:test
+```
+
+For release-sensitive changes, also run `npm run rust:test`. For documentation-only changes, a visual review of the rendered Markdown is usually enough.
 
 ## Security
 
-Please do not open public issues for sensitive security problems. Use GitHub's private vulnerability reporting flow if it is enabled for the repository, or contact the maintainers directly.
+Please do not open public issues for sensitive security problems. See [SECURITY.md](SECURITY.md) for the reporting process.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,17 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please do not report security vulnerabilities through public GitHub issues.
+
+Use GitHub's private vulnerability reporting flow for this repository when it is available. Include a clear description, affected versions, reproduction steps or proof of concept, impact, and any suggested mitigation.
+
+If private reporting is unavailable, contact the maintainers through the project Discord and ask for a private reporting channel. Do not include exploit details in the public message.
+
+## Scope
+
+Reports involving the Loom MCP server, installers, release artifacts, bundled runtime dependencies, and supported agent integrations are in scope.
+
+## Disclosure
+
+Please give maintainers reasonable time to investigate and release a fix before publicly disclosing a vulnerability. We will acknowledge a valid report, assess its impact, and coordinate remediation and disclosure with the reporter.

--- a/src/rust/contracts/execution.rs
+++ b/src/rust/contracts/execution.rs
@@ -942,6 +942,23 @@ pub struct TaskResult {
     pub no_change_reason: Option<TaskResultNoChangeReason>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub verification_results: Vec<VerificationResult>,
+    /// Optional shared verification state. Older TaskResults remain valid;
+    /// new producers can attach the attempt, findings, repair, and latest
+    /// delivery result without creating a second result format.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub verification_history: Option<crate::VerificationHistory>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub verification_attempt: Option<crate::VerificationAttempt>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub verification_findings: Vec<crate::VerificationFinding>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub repair_contract: Option<crate::RepairContract>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub delivery_result: Option<crate::DeliveryResult>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub training_telemetry: Vec<crate::TrainingTelemetryRecord>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub verification_analysis: Option<crate::VerificationAnalysisSummary>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub implementation_obligation_results: Vec<TaskImplementationObligationResult>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/rust/contracts/lib.rs
+++ b/src/rust/contracts/lib.rs
@@ -8,6 +8,7 @@ pub mod execution;
 pub mod planning;
 pub mod review;
 pub mod ui_quality;
+pub mod verification;
 
 pub use api_quality::*;
 pub use architecture::*;
@@ -19,6 +20,7 @@ pub use execution::*;
 pub use planning::*;
 pub use review::*;
 pub use ui_quality::*;
+pub use verification::*;
 
 pub fn module_name() -> &'static str {
     "contracts"

--- a/src/rust/contracts/review.rs
+++ b/src/rust/contracts/review.rs
@@ -148,6 +148,22 @@ pub struct ReviewResult {
     pub decision: String,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub findings: Vec<ReviewFinding>,
+    /// Review and V-SEFM can consume the same attempt and repair references
+    /// as TaskResult instead of inventing a parallel verification identity.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub verification_history: Option<crate::VerificationHistory>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub verification_attempt: Option<crate::VerificationAttempt>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub verification_findings: Vec<crate::VerificationFinding>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub repair_contract: Option<crate::RepairContract>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub delivery_result: Option<crate::DeliveryResult>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub training_telemetry: Vec<crate::TrainingTelemetryRecord>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub verification_analysis: Option<crate::VerificationAnalysisSummary>,
     pub coverage_assessment: ReviewCoverageAssessment,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub limitations: Vec<ReviewLimitation>,

--- a/src/rust/contracts/ui_quality.rs
+++ b/src/rust/contracts/ui_quality.rs
@@ -575,7 +575,7 @@ fn ui_surface_layout_model_shape() -> Value {
         "desktop": {
             "layoutIntent": "string",
             "allowedPresentations": [UI_PRESENTATION_KINDS.join(" | ")],
-            "forbiddenPresentations": ["string"]
+            "forbiddenPresentations": [UI_PRESENTATION_KINDS.join(" | ")]
         },
         "tablet": {
             "layoutIntent": "string",
@@ -649,9 +649,9 @@ fn ui_surface_state_model_shape() -> Value {
 
 fn ui_surface_composition_constraints_shape() -> Value {
     json!({
-        "requiredComposition": ["string"],
-        "forbiddenComposition": ["string"],
-        "antiDemoRules": ["string"],
+        "requiredComposition": [UI_COMPOSITION_CONSTRAINT_KINDS.join(" | ")],
+        "forbiddenComposition": [UI_COMPOSITION_CONSTRAINT_KINDS.join(" | ")],
+        "antiDemoRules": [UI_COMPOSITION_CONSTRAINT_KINDS.join(" | ")],
         "customRules": ["required when known constraints do not cover the product surface"]
     })
 }
@@ -667,7 +667,7 @@ fn ui_surface_content_boundary_shape() -> Value {
             "business_feedback",
             "help_entry"
         ],
-        "forbiddenUserVisibleContent": ["string"],
+        "forbiddenUserVisibleContent": [UI_FORBIDDEN_USER_VISIBLE_CONTENT.join(" | ")],
         "customForbiddenContent": ["required when product-specific content must be blocked"],
         "copyRule": "Use product language for the user task; do not show delivery, runtime, stack, validator, or generated artifact language unless the product mode requires it."
     })

--- a/src/rust/contracts/verification.rs
+++ b/src/rust/contracts/verification.rs
@@ -1,0 +1,1274 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+
+/// Shared lifecycle objects used to connect TaskResult, Review, V-SEFM, and
+/// repair outcomes without changing the existing delivery routing.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum VerificationLifecycleStatus {
+    Pending,
+    Checked,
+    Passed,
+    Failed,
+    Blocked,
+    RepairPending,
+    Reverified,
+    CompletedWithNotes,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum AnalysisCompleteness {
+    Complete,
+    Incomplete,
+}
+
+/// The two operational failure classes needed by the delivery loop. A code
+/// failure can be repaired in the repository; an environment block needs a
+/// dependency or runtime action before verification can continue.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, JsonSchema,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum VerificationFailureClass {
+    CodeFailure,
+    EnvironmentBlocked,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct VerificationAssertion {
+    pub assertion_id: String,
+    pub target: String,
+    #[serde(default)]
+    pub preconditions: Vec<String>,
+    pub expected_result: String,
+    #[serde(default)]
+    pub evidence_requirements: Vec<String>,
+    pub source_ref: String,
+    pub contract_version: String,
+    pub status: VerificationLifecycleStatus,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct VerificationEvidenceRecord {
+    pub evidence_id: String,
+    #[serde(default)]
+    pub assertion_refs: Vec<String>,
+    pub source: String,
+    pub location: String,
+    pub observed_result: String,
+    pub captured_at: String,
+}
+
+impl VerificationEvidenceRecord {
+    pub fn is_locatable(&self) -> bool {
+        !self.location.trim().is_empty()
+    }
+
+    pub fn is_complete(&self) -> bool {
+        self.is_locatable()
+            && !self.source.trim().is_empty()
+            && !self.observed_result.trim().is_empty()
+            && !self.captured_at.trim().is_empty()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct VerificationFinding {
+    pub finding_id: String,
+    pub severity: String,
+    pub failure_owner: String,
+    pub classification: VerificationFailureClass,
+    pub message: String,
+    #[serde(default)]
+    pub affected_assertion_refs: Vec<String>,
+    pub remediation: String,
+}
+
+impl VerificationFinding {
+    pub fn is_environment_blocked(&self) -> bool {
+        matches!(
+            self.classification,
+            VerificationFailureClass::EnvironmentBlocked
+        )
+    }
+
+    pub fn is_code_failure(&self) -> bool {
+        matches!(self.classification, VerificationFailureClass::CodeFailure)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RepairContract {
+    pub repair_id: String,
+    #[serde(default)]
+    pub finding_refs: Vec<String>,
+    #[serde(default)]
+    pub affected_assertion_refs: Vec<String>,
+    pub repair_scope: String,
+    #[serde(default)]
+    pub required_checks: Vec<String>,
+    pub source_contract_ref: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub verification_contract_version: Option<String>,
+    pub status: VerificationLifecycleStatus,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct VerificationAttempt {
+    pub attempt_id: String,
+    pub attempt_number: u32,
+    #[serde(default)]
+    pub assertion_refs: Vec<String>,
+    #[serde(default)]
+    pub evidence_refs: Vec<String>,
+    pub source_version: String,
+    pub contract_version: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repair_ref: Option<String>,
+    pub status: VerificationLifecycleStatus,
+    pub started_at: String,
+    pub completed_at: String,
+}
+
+impl VerificationAttempt {
+    pub fn is_verified(&self, evidence: &[VerificationEvidenceRecord]) -> bool {
+        self.is_completion_eligible(evidence)
+    }
+
+    fn has_complete_evidence_for_assertions(
+        &self,
+        evidence: &[VerificationEvidenceRecord],
+    ) -> bool {
+        !self.assertion_refs.is_empty()
+            && !self.evidence_refs.is_empty()
+            && self.assertion_refs.iter().all(|assertion_ref| {
+                self.evidence_refs.iter().any(|evidence_ref| {
+                    evidence.iter().any(|item| {
+                        item.evidence_id == *evidence_ref
+                            && item.is_complete()
+                            && item
+                                .assertion_refs
+                                .iter()
+                                .any(|item_assertion| item_assertion == assertion_ref)
+                    })
+                })
+            })
+            && self.evidence_refs.iter().all(|evidence_ref| {
+                evidence.iter().any(|item| {
+                    item.evidence_id == *evidence_ref
+                        && item.is_complete()
+                        && item
+                            .assertion_refs
+                            .iter()
+                            .any(|assertion_ref| self.assertion_refs.contains(assertion_ref))
+                })
+            })
+    }
+
+    pub fn can_pass(&self, evidence: &[VerificationEvidenceRecord]) -> bool {
+        matches!(
+            self.status,
+            VerificationLifecycleStatus::Checked
+                | VerificationLifecycleStatus::Passed
+                | VerificationLifecycleStatus::Reverified
+        ) && !self.source_version.trim().is_empty()
+            && !self.contract_version.trim().is_empty()
+            && !self.started_at.trim().is_empty()
+            && !self.completed_at.trim().is_empty()
+            && self.has_complete_evidence_for_assertions(evidence)
+    }
+
+    pub fn is_completion_eligible(&self, evidence: &[VerificationEvidenceRecord]) -> bool {
+        matches!(
+            self.status,
+            VerificationLifecycleStatus::Passed | VerificationLifecycleStatus::Reverified
+        ) && self.can_pass(evidence)
+    }
+
+    pub fn is_fresh_for_repair(&self, repair: &RepairContract) -> bool {
+        self.repair_ref.as_deref() == Some(repair.repair_id.as_str())
+            && self.contract_version == repair.source_contract_ref
+            && !self.evidence_refs.is_empty()
+            && repair
+                .affected_assertion_refs
+                .iter()
+                .all(|assertion_ref| self.assertion_refs.contains(assertion_ref))
+    }
+}
+
+/// Append-only verification history owned by the persistence boundary.
+///
+/// This is intentionally a contract-level guard rather than a storage
+/// implementation. State writers can use it to reject duplicate or stale
+/// attempts before persisting a new record.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct VerificationHistory {
+    #[serde(default)]
+    pub attempts: Vec<VerificationAttempt>,
+    #[serde(default)]
+    pub repairs: Vec<RepairContract>,
+    #[serde(default)]
+    pub evidence: Vec<VerificationEvidenceRecord>,
+}
+
+impl VerificationHistory {
+    pub fn append_evidence(
+        &mut self,
+        evidence: VerificationEvidenceRecord,
+    ) -> Result<(), &'static str> {
+        if evidence.evidence_id.trim().is_empty() {
+            return Err("evidence id must not be empty");
+        }
+        if evidence.assertion_refs.is_empty()
+            || !references_are_unique_and_nonempty(&evidence.assertion_refs)
+        {
+            return Err("evidence must reference at least one assertion");
+        }
+        if !evidence.is_complete() {
+            return Err("evidence must include source, location, result, and capture time");
+        }
+        if self
+            .evidence
+            .iter()
+            .any(|existing| existing.evidence_id == evidence.evidence_id)
+        {
+            return Err("evidence id already exists");
+        }
+        self.evidence.push(evidence);
+        Ok(())
+    }
+
+    pub fn append_repair(&mut self, repair: RepairContract) -> Result<(), &'static str> {
+        if repair.repair_id.trim().is_empty() {
+            return Err("repair id must not be empty");
+        }
+        if repair.source_contract_ref.trim().is_empty() {
+            return Err("repair source contract must not be empty");
+        }
+        if repair.repair_scope.trim().is_empty() {
+            return Err("repair scope must not be empty");
+        }
+        if repair.affected_assertion_refs.is_empty()
+            || !references_are_unique_and_nonempty(&repair.affected_assertion_refs)
+        {
+            return Err("repair must affect at least one assertion");
+        }
+        if self
+            .repairs
+            .iter()
+            .any(|existing| existing.repair_id == repair.repair_id)
+        {
+            return Err("repair id already exists");
+        }
+        self.repairs.push(repair);
+        Ok(())
+    }
+
+    pub fn append_attempt(&mut self, attempt: VerificationAttempt) -> Result<(), &'static str> {
+        if attempt.attempt_id.trim().is_empty() {
+            return Err("attempt id must not be empty");
+        }
+        if attempt.attempt_number == 0 {
+            return Err("attempt number must be positive");
+        }
+        if attempt.source_version.trim().is_empty() {
+            return Err("attempt source version must not be empty");
+        }
+        if attempt.contract_version.trim().is_empty() {
+            return Err("attempt contract version must not be empty");
+        }
+        if attempt.started_at.trim().is_empty() || attempt.completed_at.trim().is_empty() {
+            return Err("attempt timestamps must not be empty");
+        }
+        if attempt.assertion_refs.is_empty()
+            || !references_are_unique_and_nonempty(&attempt.assertion_refs)
+        {
+            return Err("attempt must reference at least one assertion");
+        }
+        if attempt.evidence_refs.is_empty()
+            || !references_are_unique_and_nonempty(&attempt.evidence_refs)
+        {
+            return Err("attempt must reference at least one evidence record");
+        }
+        if self
+            .attempts
+            .iter()
+            .any(|existing| existing.attempt_id == attempt.attempt_id)
+        {
+            return Err("attempt id already exists");
+        }
+        if let Some(previous) = self.attempts.last() {
+            if attempt.attempt_number <= previous.attempt_number {
+                return Err("attempt number must increase monotonically");
+            }
+        }
+        if let Some(repair_ref) = attempt.repair_ref.as_deref() {
+            if !self
+                .repairs
+                .iter()
+                .any(|repair| repair.repair_id == repair_ref)
+            {
+                return Err("attempt references an unknown repair");
+            }
+            let repair = self
+                .repairs
+                .iter()
+                .find(|repair| repair.repair_id == repair_ref)
+                .expect("repair was checked above");
+            if repair
+                .affected_assertion_refs
+                .iter()
+                .any(|assertion_ref| !attempt.assertion_refs.contains(assertion_ref))
+            {
+                return Err("repair attempt must cover every affected assertion");
+            }
+            if matches!(
+                attempt.status,
+                VerificationLifecycleStatus::Checked | VerificationLifecycleStatus::Passed
+            ) {
+                return Err("a repair attempt requires a separate reverification result");
+            }
+        } else if matches!(attempt.status, VerificationLifecycleStatus::Reverified) {
+            return Err("reverified attempt requires a repair reference");
+        }
+        if !attempt.has_complete_evidence_for_assertions(&self.evidence) {
+            return Err("attempt must have complete evidence for every assertion");
+        }
+
+        self.attempts.push(attempt);
+        Ok(())
+    }
+
+    pub fn validate(&self, delivery: Option<&DeliveryResult>) -> Result<(), &'static str> {
+        let mut canonical = Self::default();
+        for evidence in &self.evidence {
+            canonical.append_evidence(evidence.clone())?;
+        }
+        for repair in &self.repairs {
+            canonical.append_repair(repair.clone())?;
+        }
+        for attempt in &self.attempts {
+            canonical.append_attempt(attempt.clone())?;
+        }
+
+        let known_assertions = self
+            .attempts
+            .iter()
+            .flat_map(|attempt| attempt.assertion_refs.iter())
+            .chain(
+                self.repairs
+                    .iter()
+                    .flat_map(|repair| repair.affected_assertion_refs.iter()),
+            )
+            .collect::<BTreeSet<_>>();
+        for evidence in &self.evidence {
+            if evidence
+                .assertion_refs
+                .iter()
+                .any(|assertion_ref| !known_assertions.contains(assertion_ref))
+            {
+                return Err("evidence references an unknown assertion");
+            }
+        }
+        for attempt in &self.attempts {
+            if attempt.evidence_refs.iter().any(|evidence_ref| {
+                !self
+                    .evidence
+                    .iter()
+                    .any(|record| record.evidence_id == *evidence_ref)
+            }) {
+                return Err("attempt references an unknown evidence record");
+            }
+            if matches!(
+                attempt.status,
+                VerificationLifecycleStatus::Passed | VerificationLifecycleStatus::Reverified
+            ) && !attempt.is_completion_eligible(&self.evidence)
+            {
+                return Err("successful attempt lacks complete evidence");
+            }
+            if let Some(repair_ref) = attempt.repair_ref.as_deref() {
+                let repair = self
+                    .repairs
+                    .iter()
+                    .find(|repair| repair.repair_id == repair_ref)
+                    .ok_or("attempt references an unknown repair")?;
+                if matches!(attempt.status, VerificationLifecycleStatus::Reverified)
+                    && !attempt.is_fresh_for_repair(repair)
+                {
+                    return Err("reverification does not match the repair contract");
+                }
+            }
+        }
+        if let Some(delivery) = delivery {
+            self.validate_delivery_result(delivery, &self.evidence)?;
+        }
+        Ok(())
+    }
+
+    pub fn validate_delivery_result(
+        &self,
+        delivery: &DeliveryResult,
+        evidence: &[VerificationEvidenceRecord],
+    ) -> Result<(), &'static str> {
+        let attempt = self
+            .attempts
+            .iter()
+            .find(|attempt| attempt.attempt_id == delivery.latest_attempt_ref)
+            .ok_or("delivery references an unknown attempt")?;
+        if delivery.delivery_result_id.trim().is_empty()
+            || delivery.latest_attempt_ref.trim().is_empty()
+            || delivery.latest_source_ref.trim().is_empty()
+            || delivery.contract_version.trim().is_empty()
+        {
+            return Err("delivery result is missing required references");
+        }
+        if self
+            .attempts
+            .last()
+            .map(|latest| latest.attempt_id.as_str())
+            != Some(attempt.attempt_id.as_str())
+        {
+            return Err("delivery must reference the latest verification attempt");
+        }
+        if delivery.latest_source_ref != attempt.source_version {
+            return Err("delivery source does not match the referenced attempt");
+        }
+        if delivery.contract_version != attempt.contract_version {
+            return Err("delivery contract does not match the referenced attempt");
+        }
+        if delivery.is_completion_evidence() {
+            if !attempt.is_completion_eligible(evidence) {
+                return Err("delivery cannot be successful without verified evidence");
+            }
+            if matches!(attempt.status, VerificationLifecycleStatus::Reverified)
+                && attempt.repair_ref.is_none()
+            {
+                return Err("reverified delivery requires a repair-linked attempt");
+            }
+            if let Some(repair_ref) = attempt.repair_ref.as_deref() {
+                let repair = self
+                    .repairs
+                    .iter()
+                    .find(|repair| repair.repair_id == repair_ref)
+                    .ok_or("delivery references an attempt with an unknown repair")?;
+                if !matches!(attempt.status, VerificationLifecycleStatus::Reverified)
+                    || !attempt.is_fresh_for_repair(repair)
+                {
+                    return Err("delivery repair lineage is incomplete");
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub fn latest_verified_attempt(
+        &self,
+        evidence: &[VerificationEvidenceRecord],
+    ) -> Option<&VerificationAttempt> {
+        self.attempts
+            .iter()
+            .rev()
+            .find(|attempt| attempt.is_completion_eligible(evidence))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct DeliveryResult {
+    pub delivery_result_id: String,
+    pub latest_attempt_ref: String,
+    pub latest_source_ref: String,
+    pub contract_version: String,
+    pub status: VerificationLifecycleStatus,
+    #[serde(default)]
+    pub finding_refs: Vec<String>,
+    #[serde(default)]
+    pub notes: Vec<String>,
+}
+
+impl DeliveryResult {
+    pub fn is_completion_evidence(&self) -> bool {
+        matches!(
+            self.status,
+            VerificationLifecycleStatus::Passed
+                | VerificationLifecycleStatus::Reverified
+                | VerificationLifecycleStatus::CompletedWithNotes
+        )
+    }
+}
+
+fn references_are_unique_and_nonempty(references: &[String]) -> bool {
+    let mut seen = BTreeSet::new();
+    references
+        .iter()
+        .all(|reference| !reference.trim().is_empty() && seen.insert(reference))
+}
+
+/// Read-only projection of verification history for MCP and structured result
+/// consumers. It is derived from committed records and never becomes a new
+/// source of delivery truth.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct VerificationAnalysisSummary {
+    pub status: Option<VerificationLifecycleStatus>,
+    pub attempt_count: u32,
+    pub repair_count: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub latest_attempt_ref: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub delivery_result_ref: Option<String>,
+    pub telemetry_complete: bool,
+    pub completeness: AnalysisCompleteness,
+    #[serde(default)]
+    pub missing_evidence: Vec<String>,
+    #[serde(default)]
+    pub failure_classes: Vec<VerificationFailureClass>,
+    #[serde(default)]
+    pub source_refs: Vec<String>,
+    #[serde(default)]
+    pub evidence_refs: Vec<String>,
+}
+
+impl VerificationAnalysisSummary {
+    pub fn from_history(
+        attempts: &[VerificationAttempt],
+        repairs: &[RepairContract],
+        delivery_result: Option<&DeliveryResult>,
+        telemetry: &[TrainingTelemetryRecord],
+        findings: &[VerificationFinding],
+    ) -> Self {
+        Self::from_history_with_evidence(
+            attempts,
+            repairs,
+            delivery_result,
+            telemetry,
+            findings,
+            None,
+        )
+    }
+
+    pub fn from_history_with_evidence(
+        attempts: &[VerificationAttempt],
+        repairs: &[RepairContract],
+        delivery_result: Option<&DeliveryResult>,
+        telemetry: &[TrainingTelemetryRecord],
+        findings: &[VerificationFinding],
+        evidence: Option<&[VerificationEvidenceRecord]>,
+    ) -> Self {
+        let latest = attempts.last();
+        let telemetry_attempts = telemetry
+            .iter()
+            .map(|record| record.source_attempt_ref.as_str())
+            .collect::<BTreeSet<_>>();
+        let mut source_refs = BTreeSet::new();
+        let mut evidence_refs = BTreeSet::new();
+        for attempt in attempts {
+            source_refs.insert(attempt.source_version.clone());
+            evidence_refs.extend(attempt.evidence_refs.iter().cloned());
+        }
+
+        let mut missing_evidence = Vec::new();
+        if attempts.is_empty() {
+            missing_evidence.push("verification_attempts".to_string());
+        }
+        for attempt in attempts {
+            if attempt.source_version.trim().is_empty() {
+                missing_evidence.push(format!("source:{}", attempt.attempt_id));
+            }
+            if attempt.evidence_refs.is_empty() {
+                missing_evidence.push(format!("evidence:{}", attempt.attempt_id));
+            }
+        }
+        if let Some(evidence) = evidence {
+            for evidence_ref in &evidence_refs {
+                if !evidence
+                    .iter()
+                    .any(|item| item.evidence_id == *evidence_ref && item.is_complete())
+                {
+                    missing_evidence.push(format!("evidence_ref:{evidence_ref}"));
+                }
+            }
+        }
+        if let Some(delivery) = delivery_result {
+            match latest {
+                Some(attempt) if delivery.latest_attempt_ref == attempt.attempt_id => {}
+                Some(_) => missing_evidence.push("delivery_latest_attempt".to_string()),
+                None => missing_evidence.push("delivery_attempt".to_string()),
+            }
+            if delivery.latest_source_ref.trim().is_empty() {
+                missing_evidence.push("delivery_source".to_string());
+            } else if latest
+                .map(|attempt| attempt.source_version.as_str())
+                .filter(|source| *source != delivery.latest_source_ref)
+                .is_some()
+            {
+                missing_evidence.push("delivery_source_mismatch".to_string());
+            }
+            if !delivery.is_completion_evidence() {
+                missing_evidence.push("delivery_not_complete".to_string());
+            }
+            if let Some(evidence) = evidence {
+                let history = VerificationHistory {
+                    attempts: attempts.to_vec(),
+                    repairs: repairs.to_vec(),
+                    evidence: evidence.to_vec(),
+                };
+                if history
+                    .validate_delivery_result(delivery, evidence)
+                    .is_err()
+                {
+                    missing_evidence.push("delivery_unverified".to_string());
+                }
+            }
+        } else {
+            missing_evidence.push("delivery_result".to_string());
+        }
+
+        missing_evidence.sort();
+        missing_evidence.dedup();
+
+        Self {
+            status: latest.map(|attempt| attempt.status.clone()),
+            attempt_count: attempts.len() as u32,
+            repair_count: repairs.len() as u32,
+            latest_attempt_ref: latest.map(|attempt| attempt.attempt_id.clone()),
+            delivery_result_ref: delivery_result.map(|result| result.delivery_result_id.clone()),
+            telemetry_complete: !attempts.is_empty()
+                && attempts
+                    .iter()
+                    .all(|attempt| telemetry_attempts.contains(attempt.attempt_id.as_str())),
+            completeness: if missing_evidence.is_empty() {
+                AnalysisCompleteness::Complete
+            } else {
+                AnalysisCompleteness::Incomplete
+            },
+            missing_evidence,
+            failure_classes: findings
+                .iter()
+                .map(|finding| finding.classification)
+                .collect::<BTreeSet<_>>()
+                .into_iter()
+                .collect(),
+            source_refs: source_refs.into_iter().collect(),
+            evidence_refs: evidence_refs.into_iter().collect(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct TrainingTelemetryStateTransition {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub from: Option<VerificationLifecycleStatus>,
+    pub to: VerificationLifecycleStatus,
+    pub trigger: String,
+}
+
+/// A derived learning signal. It keeps the source verification references so
+/// future consumers can reconstruct the delivery trajectory without treating
+/// telemetry as a second delivery result.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct TrainingTelemetryRecord {
+    pub telemetry_id: String,
+    pub source_event_ref: String,
+    pub source_attempt_ref: String,
+    pub outcome: String,
+    pub state_transition: TrainingTelemetryStateTransition,
+    #[serde(default)]
+    pub evidence_refs: Vec<String>,
+    pub schema_version: String,
+}
+
+impl TrainingTelemetryRecord {
+    pub fn from_attempt(
+        telemetry_id: impl Into<String>,
+        source_event_ref: impl Into<String>,
+        attempt: &VerificationAttempt,
+        outcome: impl Into<String>,
+        from: Option<VerificationLifecycleStatus>,
+        trigger: impl Into<String>,
+    ) -> Option<Self> {
+        let source_event_ref = source_event_ref.into();
+        if source_event_ref.trim().is_empty() || attempt.attempt_id.trim().is_empty() {
+            return None;
+        }
+
+        Some(Self {
+            telemetry_id: telemetry_id.into(),
+            source_event_ref,
+            source_attempt_ref: attempt.attempt_id.clone(),
+            outcome: outcome.into(),
+            state_transition: TrainingTelemetryStateTransition {
+                from,
+                to: attempt.status.clone(),
+                trigger: trigger.into(),
+            },
+            evidence_refs: attempt.evidence_refs.clone(),
+            schema_version: attempt.contract_version.clone(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn evidence(location: &str) -> VerificationEvidenceRecord {
+        VerificationEvidenceRecord {
+            evidence_id: "evidence-1".to_string(),
+            assertion_refs: vec!["assertion-1".to_string()],
+            source: "cargo test".to_string(),
+            location: location.to_string(),
+            observed_result: "passed".to_string(),
+            captured_at: "2026-09-07T00:00:00Z".to_string(),
+        }
+    }
+
+    fn attempt() -> VerificationAttempt {
+        VerificationAttempt {
+            attempt_id: "attempt-1".to_string(),
+            attempt_number: 1,
+            assertion_refs: vec!["assertion-1".to_string()],
+            evidence_refs: vec!["evidence-1".to_string()],
+            source_version: "source-1".to_string(),
+            contract_version: "contract-1".to_string(),
+            repair_ref: None,
+            status: VerificationLifecycleStatus::Checked,
+            started_at: "2026-09-07T00:00:00Z".to_string(),
+            completed_at: "2026-09-07T00:00:01Z".to_string(),
+        }
+    }
+
+    #[test]
+    fn telemetry_keeps_source_attempt_and_evidence_references() {
+        let record = TrainingTelemetryRecord::from_attempt(
+            "telemetry-1",
+            "event-1",
+            &attempt(),
+            "passed",
+            Some(VerificationLifecycleStatus::Pending),
+            "verification_committed",
+        )
+        .expect("valid attempt should produce telemetry");
+
+        assert_eq!(record.source_event_ref, "event-1");
+        assert_eq!(record.source_attempt_ref, "attempt-1");
+        assert_eq!(record.evidence_refs, vec!["evidence-1"]);
+        assert_eq!(
+            record.state_transition.to,
+            VerificationLifecycleStatus::Checked
+        );
+    }
+
+    #[test]
+    fn telemetry_requires_a_source_event_and_attempt() {
+        assert!(TrainingTelemetryRecord::from_attempt(
+            "telemetry-1",
+            "",
+            &attempt(),
+            "passed",
+            None,
+            "verification_committed",
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn pass_requires_locatable_evidence_for_the_assertion() {
+        assert!(attempt().can_pass(&[evidence("tests/result.txt:12")]));
+        assert!(!attempt().can_pass(&[evidence("")]));
+    }
+
+    #[test]
+    fn pass_requires_complete_evidence_metadata() {
+        let mut incomplete = evidence("tests/result.txt:12");
+        incomplete.source.clear();
+        assert!(!attempt().can_pass(&[incomplete]));
+    }
+
+    #[test]
+    fn pending_attempt_cannot_pass_even_with_evidence() {
+        let mut pending = attempt();
+        pending.status = VerificationLifecycleStatus::Pending;
+        assert!(!pending.can_pass(&[evidence("tests/result.txt:12")]));
+    }
+
+    #[test]
+    fn every_assertion_needs_locatable_evidence() {
+        let mut attempt = attempt();
+        attempt.assertion_refs.push("assertion-2".to_string());
+        assert!(!attempt.can_pass(&[evidence("tests/result.txt:12")]));
+    }
+
+    #[test]
+    fn repair_requires_a_new_attempt_bound_to_the_repair() {
+        let repair = RepairContract {
+            repair_id: "repair-1".to_string(),
+            finding_refs: vec!["finding-1".to_string()],
+            affected_assertion_refs: vec!["assertion-1".to_string()],
+            repair_scope: "fix implementation".to_string(),
+            required_checks: vec!["cargo test".to_string()],
+            source_contract_ref: "contract-1".to_string(),
+            verification_contract_version: Some("v1".to_string()),
+            status: VerificationLifecycleStatus::RepairPending,
+        };
+        let mut attempt = attempt();
+        assert!(!attempt.is_fresh_for_repair(&repair));
+        attempt.repair_ref = Some("repair-1".to_string());
+        assert!(attempt.is_fresh_for_repair(&repair));
+    }
+
+    #[test]
+    fn findings_keep_code_and_environment_failures_distinct() {
+        let mut finding = VerificationFinding {
+            finding_id: "finding-1".to_string(),
+            severity: "high".to_string(),
+            failure_owner: "repository".to_string(),
+            classification: VerificationFailureClass::CodeFailure,
+            message: "assertion failed".to_string(),
+            affected_assertion_refs: vec!["assertion-1".to_string()],
+            remediation: "repair the implementation".to_string(),
+        };
+        assert!(finding.is_code_failure());
+        assert!(!finding.is_environment_blocked());
+        finding.classification = VerificationFailureClass::EnvironmentBlocked;
+        assert!(!finding.is_code_failure());
+        assert!(finding.is_environment_blocked());
+    }
+
+    #[test]
+    fn reverified_attempts_can_pass_but_pending_and_blocked_cannot() {
+        let mut attempt = attempt();
+        attempt.status = VerificationLifecycleStatus::Reverified;
+        assert!(attempt.can_pass(&[evidence("tests/result.txt:12")]));
+
+        for status in [
+            VerificationLifecycleStatus::Pending,
+            VerificationLifecycleStatus::Failed,
+            VerificationLifecycleStatus::Blocked,
+            VerificationLifecycleStatus::RepairPending,
+        ] {
+            attempt.status = status;
+            assert!(!attempt.can_pass(&[evidence("tests/result.txt:12")]));
+        }
+    }
+
+    #[test]
+    fn history_is_append_only_and_rejects_stale_attempts() {
+        let mut history = VerificationHistory::default();
+        history
+            .append_evidence(evidence("tests/result.txt:12"))
+            .expect("evidence");
+        history.append_attempt(attempt()).expect("first attempt");
+
+        let mut stale = attempt();
+        stale.attempt_id = "attempt-2".to_string();
+        assert_eq!(
+            history.append_attempt(stale),
+            Err("attempt number must increase monotonically")
+        );
+        assert_eq!(history.attempts.len(), 1);
+    }
+
+    #[test]
+    fn history_rejects_attempts_without_complete_evidence_coverage() {
+        let mut history = VerificationHistory::default();
+        let candidate = attempt();
+
+        assert_eq!(
+            history.append_attempt(candidate.clone()),
+            Err("attempt must have complete evidence for every assertion")
+        );
+
+        history
+            .append_evidence(evidence("tests/result.txt:12"))
+            .expect("evidence");
+        let mut uncovered = candidate;
+        uncovered.assertion_refs = vec!["assertion-2".to_string()];
+
+        assert_eq!(
+            history.append_attempt(uncovered),
+            Err("attempt must have complete evidence for every assertion")
+        );
+        assert!(history.attempts.is_empty());
+    }
+
+    #[test]
+    fn history_rejects_untraceable_attempts_and_repairs() {
+        let mut history = VerificationHistory::default();
+        let mut invalid_attempt = attempt();
+        invalid_attempt.source_version.clear();
+        assert_eq!(
+            history.append_attempt(invalid_attempt),
+            Err("attempt source version must not be empty")
+        );
+
+        let invalid_repair = RepairContract {
+            repair_id: "repair-1".to_string(),
+            finding_refs: vec![],
+            affected_assertion_refs: vec![],
+            repair_scope: "fix implementation".to_string(),
+            required_checks: vec!["cargo test".to_string()],
+            source_contract_ref: "contract-1".to_string(),
+            verification_contract_version: None,
+            status: VerificationLifecycleStatus::RepairPending,
+        };
+        assert_eq!(
+            history.append_repair(invalid_repair),
+            Err("repair must affect at least one assertion")
+        );
+    }
+
+    #[test]
+    fn delivery_result_must_match_verified_attempt_source() {
+        let history = VerificationHistory {
+            attempts: vec![attempt()],
+            repairs: vec![],
+            evidence: vec![evidence("tests/result.txt:12")],
+        };
+        let delivery = DeliveryResult {
+            delivery_result_id: "delivery-1".to_string(),
+            latest_attempt_ref: "attempt-1".to_string(),
+            latest_source_ref: "different-source".to_string(),
+            contract_version: "contract-1".to_string(),
+            status: VerificationLifecycleStatus::Passed,
+            finding_refs: vec![],
+            notes: vec![],
+        };
+        assert_eq!(
+            history.validate_delivery_result(&delivery, &[evidence("tests/result.txt:12")]),
+            Err("delivery source does not match the referenced attempt")
+        );
+    }
+
+    #[test]
+    fn repair_attempt_cannot_be_recorded_as_verified_without_reverification() {
+        let mut history = VerificationHistory::default();
+        history
+            .append_repair(RepairContract {
+                repair_id: "repair-1".to_string(),
+                finding_refs: vec![],
+                affected_assertion_refs: vec!["assertion-1".to_string()],
+                repair_scope: "fix implementation".to_string(),
+                required_checks: vec!["cargo test".to_string()],
+                source_contract_ref: "contract-1".to_string(),
+                verification_contract_version: None,
+                status: VerificationLifecycleStatus::RepairPending,
+            })
+            .expect("repair");
+
+        let mut repaired = attempt();
+        repaired.attempt_id = "attempt-2".to_string();
+        repaired.attempt_number = 2;
+        repaired.repair_ref = Some("repair-1".to_string());
+        assert_eq!(
+            history.append_attempt(repaired),
+            Err("a repair attempt requires a separate reverification result")
+        );
+        assert!(history.attempts.is_empty());
+    }
+
+    #[test]
+    fn reverified_attempt_requires_a_repair_reference() {
+        let mut history = VerificationHistory::default();
+        history
+            .append_evidence(evidence("tests/result.txt:12"))
+            .expect("evidence");
+        let mut reverified = attempt();
+        reverified.status = VerificationLifecycleStatus::Reverified;
+
+        assert_eq!(
+            history.append_attempt(reverified),
+            Err("reverified attempt requires a repair reference")
+        );
+        assert!(history.attempts.is_empty());
+    }
+
+    #[test]
+    fn delivery_rejects_an_unlinked_reverified_attempt() {
+        let mut reverified = attempt();
+        reverified.status = VerificationLifecycleStatus::Reverified;
+        let history = VerificationHistory {
+            attempts: vec![reverified],
+            repairs: vec![],
+            evidence: vec![evidence("tests/result.txt:12")],
+        };
+        let delivery = DeliveryResult {
+            delivery_result_id: "delivery-1".to_string(),
+            latest_attempt_ref: "attempt-1".to_string(),
+            latest_source_ref: "source-1".to_string(),
+            contract_version: "contract-1".to_string(),
+            status: VerificationLifecycleStatus::Passed,
+            finding_refs: vec![],
+            notes: vec![],
+        };
+
+        assert_eq!(
+            history.validate_delivery_result(&delivery, &history.evidence),
+            Err("reverified delivery requires a repair-linked attempt")
+        );
+    }
+
+    #[test]
+    fn history_resolves_reverification_after_repair() {
+        let mut history = VerificationHistory::default();
+        history
+            .append_evidence(evidence("tests/result.txt:12"))
+            .expect("evidence");
+        history
+            .append_repair(RepairContract {
+                repair_id: "repair-1".to_string(),
+                finding_refs: vec![],
+                affected_assertion_refs: vec!["assertion-1".to_string()],
+                repair_scope: "fix implementation".to_string(),
+                required_checks: vec!["cargo test".to_string()],
+                source_contract_ref: "contract-1".to_string(),
+                verification_contract_version: None,
+                status: VerificationLifecycleStatus::RepairPending,
+            })
+            .expect("repair");
+
+        let mut reverification = attempt();
+        reverification.attempt_id = "attempt-2".to_string();
+        reverification.attempt_number = 2;
+        reverification.repair_ref = Some("repair-1".to_string());
+        reverification.status = VerificationLifecycleStatus::Reverified;
+        history
+            .append_attempt(reverification)
+            .expect("reverification");
+
+        assert_eq!(
+            history
+                .latest_verified_attempt(&[evidence("tests/result.txt:12")])
+                .map(|item| item.attempt_id.as_str()),
+            Some("attempt-2")
+        );
+    }
+
+    #[test]
+    fn history_round_trips_through_persistence_shape() {
+        let mut history = VerificationHistory::default();
+        history
+            .append_evidence(evidence("tests/result.txt:12"))
+            .expect("evidence");
+        history.append_attempt(attempt()).expect("first attempt");
+
+        let encoded = serde_json::to_string(&history).expect("serialize history");
+        let restored: VerificationHistory =
+            serde_json::from_str(&encoded).expect("deserialize history");
+
+        assert_eq!(restored, history);
+        assert_eq!(restored.attempts[0].attempt_id, "attempt-1");
+        assert_eq!(restored.attempts[0].evidence_refs, vec!["evidence-1"]);
+        assert_eq!(restored.evidence[0].evidence_id, "evidence-1");
+    }
+
+    #[test]
+    fn lifecycle_statuses_keep_stable_wire_names() {
+        let statuses = [
+            (VerificationLifecycleStatus::Pending, "pending"),
+            (VerificationLifecycleStatus::Checked, "checked"),
+            (VerificationLifecycleStatus::Passed, "passed"),
+            (VerificationLifecycleStatus::Failed, "failed"),
+            (VerificationLifecycleStatus::Blocked, "blocked"),
+            (VerificationLifecycleStatus::RepairPending, "repair_pending"),
+            (VerificationLifecycleStatus::Reverified, "reverified"),
+            (
+                VerificationLifecycleStatus::CompletedWithNotes,
+                "completed_with_notes",
+            ),
+        ];
+
+        for (status, expected) in statuses {
+            assert_eq!(
+                serde_json::to_string(&status).unwrap(),
+                format!("\"{expected}\"")
+            );
+        }
+    }
+
+    #[test]
+    fn analysis_summary_keeps_latest_result_and_detects_missing_telemetry() {
+        let mut second = attempt();
+        second.attempt_id = "attempt-2".to_string();
+        second.attempt_number = 2;
+        second.source_version = "source-2".to_string();
+        second.repair_ref = Some("repair-1".to_string());
+        second.status = VerificationLifecycleStatus::Reverified;
+        let repair = RepairContract {
+            repair_id: "repair-1".to_string(),
+            finding_refs: vec!["finding-1".to_string()],
+            affected_assertion_refs: vec!["assertion-1".to_string()],
+            repair_scope: "fix implementation".to_string(),
+            required_checks: vec!["cargo test".to_string()],
+            source_contract_ref: "contract-1".to_string(),
+            verification_contract_version: None,
+            status: VerificationLifecycleStatus::Reverified,
+        };
+        let delivery = DeliveryResult {
+            delivery_result_id: "delivery-1".to_string(),
+            latest_attempt_ref: "attempt-2".to_string(),
+            latest_source_ref: "source-2".to_string(),
+            contract_version: "contract-1".to_string(),
+            status: VerificationLifecycleStatus::Reverified,
+            finding_refs: vec!["finding-1".to_string()],
+            notes: Vec::new(),
+        };
+        let finding = VerificationFinding {
+            finding_id: "finding-1".to_string(),
+            severity: "high".to_string(),
+            failure_owner: "repository".to_string(),
+            classification: VerificationFailureClass::CodeFailure,
+            message: "assertion failed".to_string(),
+            affected_assertion_refs: vec!["assertion-1".to_string()],
+            remediation: "repair the implementation".to_string(),
+        };
+        let telemetry = TrainingTelemetryRecord::from_attempt(
+            "telemetry-1",
+            "event-1",
+            &second,
+            "reverified",
+            Some(VerificationLifecycleStatus::Failed),
+            "repair_committed",
+        )
+        .expect("valid attempt should produce telemetry");
+
+        let summary = VerificationAnalysisSummary::from_history(
+            &[attempt(), second],
+            &[repair],
+            Some(&delivery),
+            &[telemetry],
+            &[finding],
+        );
+
+        assert_eq!(
+            summary.status,
+            Some(VerificationLifecycleStatus::Reverified)
+        );
+        assert_eq!(summary.attempt_count, 2);
+        assert_eq!(summary.repair_count, 1);
+        assert_eq!(summary.latest_attempt_ref.as_deref(), Some("attempt-2"));
+        assert_eq!(summary.delivery_result_ref.as_deref(), Some("delivery-1"));
+        assert!(!summary.telemetry_complete);
+        assert_eq!(
+            summary.failure_classes,
+            vec![VerificationFailureClass::CodeFailure]
+        );
+        assert_eq!(summary.completeness, AnalysisCompleteness::Complete);
+        assert!(summary.missing_evidence.is_empty());
+    }
+
+    #[test]
+    fn analysis_summary_marks_missing_evidence_instead_of_inferencing_success() {
+        let mut incomplete = attempt();
+        incomplete.source_version.clear();
+        incomplete.evidence_refs.clear();
+
+        let summary = VerificationAnalysisSummary::from_history_with_evidence(
+            &[incomplete],
+            &[],
+            None,
+            &[],
+            &[],
+            Some(&[]),
+        );
+
+        assert_eq!(summary.completeness, AnalysisCompleteness::Incomplete);
+        assert!(summary
+            .missing_evidence
+            .iter()
+            .any(|item| item == "source:attempt-1"));
+        assert!(summary
+            .missing_evidence
+            .iter()
+            .any(|item| item == "evidence:attempt-1"));
+    }
+
+    #[test]
+    fn analysis_summary_marks_unresolved_delivery_attempt() {
+        let delivery = DeliveryResult {
+            delivery_result_id: "delivery-1".to_string(),
+            latest_attempt_ref: "missing-attempt".to_string(),
+            latest_source_ref: "source-1".to_string(),
+            contract_version: "contract-1".to_string(),
+            status: VerificationLifecycleStatus::Reverified,
+            finding_refs: vec![],
+            notes: vec![],
+        };
+
+        let summary =
+            VerificationAnalysisSummary::from_history(&[attempt()], &[], Some(&delivery), &[], &[]);
+
+        assert_eq!(summary.completeness, AnalysisCompleteness::Incomplete);
+        assert_eq!(
+            summary.missing_evidence,
+            vec!["delivery_latest_attempt".to_string()]
+        );
+    }
+
+    #[test]
+    fn analysis_summary_requires_delivery_linkage() {
+        let summary = VerificationAnalysisSummary::from_history(&[attempt()], &[], None, &[], &[]);
+        assert_eq!(summary.completeness, AnalysisCompleteness::Incomplete);
+        assert!(summary
+            .missing_evidence
+            .iter()
+            .any(|item| item == "delivery_result"));
+    }
+
+    #[test]
+    fn history_requires_complete_evidence_before_accepting_delivery() {
+        let mut history = VerificationHistory::default();
+        history
+            .append_evidence(evidence("tests/result.txt:12"))
+            .expect("evidence");
+        let mut verified = attempt();
+        verified.status = VerificationLifecycleStatus::Passed;
+        history.append_attempt(verified).expect("attempt");
+        let delivery = DeliveryResult {
+            delivery_result_id: "delivery-1".to_string(),
+            latest_attempt_ref: "attempt-1".to_string(),
+            latest_source_ref: "source-1".to_string(),
+            contract_version: "contract-1".to_string(),
+            status: VerificationLifecycleStatus::Passed,
+            finding_refs: vec![],
+            notes: vec![],
+        };
+
+        assert_eq!(history.validate(Some(&delivery)), Ok(()));
+    }
+
+    #[test]
+    fn history_rejects_delivery_with_a_mismatched_contract() {
+        let mut history = VerificationHistory::default();
+        history
+            .append_evidence(evidence("tests/result.txt:12"))
+            .expect("evidence");
+        let mut verified = attempt();
+        verified.status = VerificationLifecycleStatus::Passed;
+        history.append_attempt(verified).expect("attempt");
+        let delivery = DeliveryResult {
+            delivery_result_id: "delivery-1".to_string(),
+            latest_attempt_ref: "attempt-1".to_string(),
+            latest_source_ref: "source-1".to_string(),
+            contract_version: "different-contract".to_string(),
+            status: VerificationLifecycleStatus::Passed,
+            finding_refs: vec![],
+            notes: vec![],
+        };
+
+        assert_eq!(
+            history.validate(Some(&delivery)),
+            Err("delivery contract does not match the referenced attempt")
+        );
+    }
+}

--- a/src/rust/execution/review.rs
+++ b/src/rust/execution/review.rs
@@ -5324,6 +5324,22 @@ fn compact_task_result_summaries(task_results: &[TaskResult]) -> Vec<Value> {
                         }).collect::<Vec<_>>()
                     })
                 }).collect::<Vec<_>>(),
+                "verificationHistory": result.verification_history.as_ref().map(|history| json!({
+                    "attemptCount": history.attempts.len(),
+                    "repairCount": history.repairs.len(),
+                    "evidenceCount": history.evidence.len(),
+                    "latestAttemptRef": history.attempts.last().map(|attempt| attempt.attempt_id.clone()),
+                    "latestSourceRef": history.attempts.last().map(|attempt| attempt.source_version.clone()),
+                    "latestContractVersion": history.attempts.last().map(|attempt| attempt.contract_version.clone())
+                })),
+                "deliveryResult": result.delivery_result.as_ref().map(|delivery| json!({
+                    "deliveryResultId": delivery.delivery_result_id,
+                    "latestAttemptRef": delivery.latest_attempt_ref,
+                    "latestSourceRef": delivery.latest_source_ref,
+                    "contractVersion": delivery.contract_version,
+                    "status": delivery.status
+                })),
+                "verificationAnalysis": compact_verification_readback(result),
                 "requirementDetailEvidence": result.requirement_detail_evidence.iter().map(|evidence| {
                     json!({
                         "detailId": evidence.detail_id,
@@ -5388,6 +5404,89 @@ fn compact_task_result_summaries(task_results: &[TaskResult]) -> Vec<Value> {
             summary
         })
         .collect()
+}
+
+/// Build the MCP-facing verification summary from the current TaskResult.
+///
+/// The review packet is a read-only projection, so it never trusts or repairs
+/// stored analysis state. It derives completeness from the task result it was
+/// given and reports broken internal references as incomplete.
+fn compact_verification_readback(result: &TaskResult) -> Option<Value> {
+    let has_verification_state = result.verification_history.is_some()
+        || result.verification_attempt.is_some()
+        || result.repair_contract.is_some()
+        || result.delivery_result.is_some()
+        || result.verification_analysis.is_some();
+    if !has_verification_state {
+        return None;
+    }
+
+    let Some(history) = result.verification_history.as_ref() else {
+        return Some(json!({
+            "status": Value::Null,
+            "attemptCount": 0,
+            "repairCount": 0,
+            "latestAttemptRef": Value::Null,
+            "deliveryResultRef": result.delivery_result.as_ref().map(|delivery| delivery.delivery_result_id.clone()),
+            "completeness": "incomplete",
+            "telemetryComplete": false,
+            "missingEvidence": ["verification_history"],
+            "failureClasses": [],
+            "sourceRefCount": 0,
+            "evidenceRefCount": 0
+        }));
+    };
+
+    let analysis = contracts::VerificationAnalysisSummary::from_history_with_evidence(
+        &history.attempts,
+        &history.repairs,
+        result.delivery_result.as_ref(),
+        &result.training_telemetry,
+        &result.verification_findings,
+        Some(&history.evidence),
+    );
+    let mut missing_evidence = analysis.missing_evidence.clone();
+
+    if history.validate(result.delivery_result.as_ref()).is_err() {
+        missing_evidence.push("verification_history_invalid".to_string());
+    }
+    if result
+        .verification_attempt
+        .as_ref()
+        .is_some_and(|attempt| history.attempts.last() != Some(attempt))
+    {
+        missing_evidence.push("verification_attempt_unresolved".to_string());
+    }
+    if result.repair_contract.as_ref().is_some_and(|repair| {
+        !history
+            .repairs
+            .iter()
+            .any(|known_repair| known_repair == repair)
+    }) {
+        missing_evidence.push("repair_contract_unresolved".to_string());
+    }
+    missing_evidence.sort();
+    missing_evidence.dedup();
+
+    let completeness = if missing_evidence.is_empty() {
+        contracts::AnalysisCompleteness::Complete
+    } else {
+        contracts::AnalysisCompleteness::Incomplete
+    };
+
+    Some(json!({
+        "status": analysis.status,
+        "attemptCount": analysis.attempt_count,
+        "repairCount": analysis.repair_count,
+        "latestAttemptRef": analysis.latest_attempt_ref,
+        "deliveryResultRef": analysis.delivery_result_ref,
+        "completeness": completeness,
+        "telemetryComplete": analysis.telemetry_complete,
+        "missingEvidence": missing_evidence,
+        "failureClasses": analysis.failure_classes,
+        "sourceRefCount": analysis.source_refs.len(),
+        "evidenceRefCount": analysis.evidence_refs.len()
+    }))
 }
 
 fn compact_summary(value: &str) -> String {
@@ -6083,6 +6182,124 @@ mod tests {
         assert_eq!(
             retried[0]["verificationResults"][0]["browserChecks"][0]["diagnosticArtifactRefs"][0],
             json!("test-results/workflow/trace.zip")
+        );
+    }
+
+    #[test]
+    fn compact_task_result_summary_keeps_read_only_verification_context() {
+        let mut result = task_result_with_browser_check(1);
+        result.verification_history = Some(contracts::VerificationHistory::default());
+        result.verification_analysis = Some(contracts::VerificationAnalysisSummary {
+            status: None,
+            attempt_count: 0,
+            repair_count: 0,
+            latest_attempt_ref: None,
+            delivery_result_ref: None,
+            telemetry_complete: false,
+            completeness: contracts::AnalysisCompleteness::Incomplete,
+            missing_evidence: vec!["verification_attempts".to_string()],
+            failure_classes: vec![],
+            source_refs: vec![],
+            evidence_refs: vec![],
+        });
+
+        let summary = compact_task_result_summaries(&[result]);
+
+        assert_eq!(summary[0]["verificationHistory"]["attemptCount"], json!(0));
+        assert_eq!(
+            summary[0]["verificationAnalysis"]["completeness"],
+            json!("incomplete")
+        );
+        assert_eq!(
+            summary[0]["verificationAnalysis"]["missingEvidence"],
+            json!(["delivery_result", "verification_attempts"])
+        );
+    }
+
+    #[test]
+    fn compact_task_result_summary_derives_readback_from_the_current_result_only() {
+        let evidence = contracts::VerificationEvidenceRecord {
+            evidence_id: "evidence-current".to_string(),
+            assertion_refs: vec!["assertion-current".to_string()],
+            source: "cargo test -p execution".to_string(),
+            location: "src/rust/execution/review.rs".to_string(),
+            observed_result: "passed".to_string(),
+            captured_at: "2026-09-07T00:00:00Z".to_string(),
+        };
+        let attempt = contracts::VerificationAttempt {
+            attempt_id: "attempt-current".to_string(),
+            attempt_number: 1,
+            assertion_refs: vec!["assertion-current".to_string()],
+            evidence_refs: vec!["evidence-current".to_string()],
+            source_version: "source-current".to_string(),
+            contract_version: "contract-current".to_string(),
+            repair_ref: None,
+            status: contracts::VerificationLifecycleStatus::Passed,
+            started_at: "2026-09-07T00:00:00Z".to_string(),
+            completed_at: "2026-09-07T00:00:01Z".to_string(),
+        };
+        let history = contracts::VerificationHistory {
+            attempts: vec![attempt.clone()],
+            repairs: vec![],
+            evidence: vec![evidence],
+        };
+        let delivery = contracts::DeliveryResult {
+            delivery_result_id: "delivery-current".to_string(),
+            latest_attempt_ref: attempt.attempt_id.clone(),
+            latest_source_ref: attempt.source_version.clone(),
+            contract_version: attempt.contract_version.clone(),
+            status: contracts::VerificationLifecycleStatus::Passed,
+            finding_refs: vec![],
+            notes: vec![],
+        };
+        let mut current = task_result_with_browser_check(1);
+        current.task_result_id = "result-current".to_string();
+        current.verification_history = Some(history);
+        current.verification_attempt = Some(attempt);
+        current.delivery_result = Some(delivery.clone());
+        current.verification_analysis = Some(contracts::VerificationAnalysisSummary {
+            status: None,
+            attempt_count: 0,
+            repair_count: 0,
+            latest_attempt_ref: None,
+            delivery_result_ref: None,
+            telemetry_complete: false,
+            completeness: contracts::AnalysisCompleteness::Incomplete,
+            missing_evidence: vec!["stale_saved_analysis".to_string()],
+            failure_classes: vec![],
+            source_refs: vec![],
+            evidence_refs: vec![],
+        });
+
+        let mut unresolved = task_result_with_browser_check(1);
+        unresolved.task_result_id = "result-unresolved".to_string();
+        unresolved.delivery_result = Some(delivery);
+
+        let current_before = serde_json::to_value(&current).expect("serialize current result");
+        let unresolved_before =
+            serde_json::to_value(&unresolved).expect("serialize unresolved result");
+        let summaries = compact_task_result_summaries(&[current.clone(), unresolved.clone()]);
+
+        assert_eq!(
+            summaries[0]["verificationAnalysis"]["completeness"],
+            json!("complete")
+        );
+        assert_eq!(
+            summaries[0]["deliveryResult"]["latestAttemptRef"],
+            json!("attempt-current")
+        );
+        assert_eq!(
+            summaries[1]["verificationAnalysis"]["completeness"],
+            json!("incomplete")
+        );
+        assert_eq!(
+            summaries[1]["verificationAnalysis"]["missingEvidence"],
+            json!(["verification_history"])
+        );
+        assert_eq!(serde_json::to_value(&current).unwrap(), current_before);
+        assert_eq!(
+            serde_json::to_value(&unresolved).unwrap(),
+            unresolved_before
         );
     }
 

--- a/src/rust/execution/task_result.rs
+++ b/src/rust/execution/task_result.rs
@@ -4,9 +4,10 @@ use std::{
 };
 
 use contracts::{
-    forbidden_jvm_package_prefixes, BrowserCheckStatus, BrowserVerificationProfile,
-    CodeQualityEvidence, CodeQualityRequirement, TaskDefinition, TaskKind, TaskPlanRunNextAction,
-    TaskPlanRunStatus, TaskResult, TaskResultStatus, TaskRunStatus, VerificationEvidence,
+    forbidden_jvm_package_prefixes, AnalysisCompleteness, BrowserCheckStatus,
+    BrowserVerificationProfile, CodeQualityEvidence, CodeQualityRequirement, TaskDefinition,
+    TaskKind, TaskPlanRunNextAction, TaskPlanRunStatus, TaskResult, TaskResultStatus,
+    TaskRunStatus, VerificationAnalysisSummary, VerificationEvidence,
 };
 use delivery_core::{
     read_selectors_value_from_paths, ArtifactKind, DeliveryLifecycleStatus, DomainDispatcher,
@@ -495,6 +496,7 @@ fn validate_result(
     }
     validate_self_repair(result, &mut issues);
     validate_verification_results(result, task, &mut issues);
+    validate_verification_analysis(result, &mut issues);
     validate_verification_provenance(project_root, result, &mut issues);
     validate_implementation_obligation_results(project_root, result, task, &mut issues);
     validate_stack_conformance(
@@ -552,6 +554,98 @@ fn validate_result(
         ));
     }
     issues
+}
+
+fn validate_verification_analysis(
+    result: &TaskResult,
+    issues: &mut Vec<delivery_core::RepairIssue>,
+) {
+    let has_verification_state = result.verification_history.is_some()
+        || result.verification_attempt.is_some()
+        || result.repair_contract.is_some()
+        || result.delivery_result.is_some()
+        || result.verification_analysis.is_some();
+    if !has_verification_state {
+        return;
+    }
+
+    let Some(history) = &result.verification_history else {
+        issues.push(issue(
+            "VERIFICATION_HISTORY_REQUIRED",
+            "verificationHistory",
+            "Verification attempts, repairs, delivery references, and summaries must resolve through verificationHistory.",
+        ));
+        return;
+    };
+
+    if let Err(message) = history.validate(result.delivery_result.as_ref()) {
+        issues.push(issue(
+            "VERIFICATION_HISTORY_INVALID",
+            "verificationHistory",
+            message,
+        ));
+    }
+
+    match (
+        history.attempts.last(),
+        result.verification_attempt.as_ref(),
+    ) {
+        (Some(latest), Some(attempt)) if latest == attempt => {}
+        (Some(_), Some(_)) => issues.push(issue(
+            "VERIFICATION_HISTORY_REF_INVALID",
+            "verificationAttempt",
+            "TaskResult verificationAttempt must match verificationHistory's latest attempt.",
+        )),
+        (None, Some(_)) => issues.push(issue(
+            "VERIFICATION_HISTORY_REF_INVALID",
+            "verificationAttempt",
+            "TaskResult verificationAttempt must resolve in verificationHistory.",
+        )),
+        _ => {}
+    }
+    if let Some(repair) = &result.repair_contract {
+        if !history.repairs.iter().any(|item| item == repair) {
+            issues.push(issue(
+                "VERIFICATION_HISTORY_REF_INVALID",
+                "repairContract",
+                "TaskResult repairContract must resolve in verificationHistory.",
+            ));
+        }
+    }
+
+    let expected_summary = VerificationAnalysisSummary::from_history_with_evidence(
+        &history.attempts,
+        &history.repairs,
+        result.delivery_result.as_ref(),
+        &result.training_telemetry,
+        &result.verification_findings,
+        Some(&history.evidence),
+    );
+    let Some(analysis) = &result.verification_analysis else {
+        issues.push(issue(
+            "VERIFICATION_ANALYSIS_REQUIRED",
+            "verificationAnalysis",
+            "Verification history must provide a derived read-only analysis summary.",
+        ));
+        return;
+    };
+
+    if analysis != &expected_summary {
+        issues.push(issue(
+            "VERIFICATION_ANALYSIS_REF_INVALID",
+            "verificationAnalysis",
+            "Verification analysis must exactly match the current TaskResult verification history, delivery result, findings, and telemetry references.",
+        ));
+    }
+    if matches!(result.status, TaskResultStatus::Completed)
+        && analysis.completeness == AnalysisCompleteness::Incomplete
+    {
+        issues.push(issue(
+            "VERIFICATION_ANALYSIS_INCOMPLETE",
+            "verificationAnalysis.completeness",
+            "A completed TaskResult with verification history cannot report incomplete analysis.",
+        ));
+    }
 }
 
 fn validate_jvm_package_names(
@@ -869,6 +963,13 @@ fn project_task_result_to_canonical_fields(object: &mut serde_json::Map<String, 
             "changedFiles",
             "noChangeReason",
             "verificationResults",
+            "verificationHistory",
+            "verificationAttempt",
+            "verificationFindings",
+            "repairContract",
+            "deliveryResult",
+            "trainingTelemetry",
+            "verificationAnalysis",
             "implementationObligationResults",
             "selfRepairSummary",
             "failure",
@@ -6157,6 +6258,10 @@ fn merge_submitted_task_result_fields(
         if conflicted_fields.contains(key.as_str()) {
             continue;
         }
+        if is_verification_state_field(key) {
+            template_object.insert(key.clone(), submitted_value.clone());
+            continue;
+        }
         if !template_object.contains_key(key) {
             continue;
         }
@@ -6168,6 +6273,19 @@ fn merge_submitted_task_result_fields(
         }
         template_object.insert(key.clone(), agent_value);
     }
+}
+
+fn is_verification_state_field(key: &str) -> bool {
+    matches!(
+        key,
+        "verificationHistory"
+            | "verificationAttempt"
+            | "verificationFindings"
+            | "repairContract"
+            | "deliveryResult"
+            | "trainingTelemetry"
+            | "verificationAnalysis"
+    )
 }
 
 fn project_agent_owned_task_result_field(key: &str, value: &Value) -> Option<Value> {
@@ -7281,5 +7399,179 @@ mod tests {
         validate_browser_verification_results(&result, Some(&profile), &mut issues);
 
         assert!(issues.is_empty(), "{issues:#?}");
+    }
+
+    fn completed_result_with_verification_history() -> TaskResult {
+        let evidence = contracts::VerificationEvidenceRecord {
+            evidence_id: "evidence-1".to_string(),
+            assertion_refs: vec!["assertion-1".to_string()],
+            source: "cargo test -p contracts verification::tests".to_string(),
+            location: "src/rust/contracts/verification.rs".to_string(),
+            observed_result: "passed".to_string(),
+            captured_at: "2026-09-07T00:00:00Z".to_string(),
+        };
+        let attempt = contracts::VerificationAttempt {
+            attempt_id: "attempt-1".to_string(),
+            attempt_number: 1,
+            assertion_refs: vec!["assertion-1".to_string()],
+            evidence_refs: vec!["evidence-1".to_string()],
+            source_version: "source-1".to_string(),
+            contract_version: "contract-1".to_string(),
+            repair_ref: None,
+            status: contracts::VerificationLifecycleStatus::Passed,
+            started_at: "2026-09-07T00:00:00Z".to_string(),
+            completed_at: "2026-09-07T00:00:01Z".to_string(),
+        };
+        let history = contracts::VerificationHistory {
+            attempts: vec![attempt.clone()],
+            repairs: vec![],
+            evidence: vec![evidence],
+        };
+        let delivery = contracts::DeliveryResult {
+            delivery_result_id: "delivery-1".to_string(),
+            latest_attempt_ref: attempt.attempt_id.clone(),
+            latest_source_ref: attempt.source_version.clone(),
+            contract_version: attempt.contract_version.clone(),
+            status: contracts::VerificationLifecycleStatus::Passed,
+            finding_refs: vec![],
+            notes: vec![],
+        };
+        let analysis = VerificationAnalysisSummary::from_history_with_evidence(
+            &history.attempts,
+            &history.repairs,
+            Some(&delivery),
+            &[],
+            &[],
+            Some(&history.evidence),
+        );
+
+        serde_json::from_value(json!({
+            "schemaVersion": "1.0",
+            "taskResultId": "result-verification",
+            "taskId": "task-verification",
+            "taskPlanId": "taskplan",
+            "status": "completed",
+            "changedFiles": ["src/rust/contracts/verification.rs"],
+            "verificationResults": [],
+            "verificationHistory": history,
+            "verificationAttempt": attempt,
+            "deliveryResult": delivery,
+            "verificationAnalysis": analysis,
+            "executionContinuity": {
+                "taskResultSubmittedAfterVerification": true,
+                "agentOwnedLongRunningWork": "none"
+            },
+            "createdAt": "2026-09-07T00:00:00Z",
+            "updatedAt": "2026-09-07T00:00:01Z"
+        }))
+        .expect("verification TaskResult")
+    }
+
+    #[test]
+    fn verification_analysis_requires_canonical_history() {
+        let mut result = completed_result_with_verification_history();
+        result.verification_history = None;
+        let mut issues = Vec::new();
+
+        validate_verification_analysis(&result, &mut issues);
+
+        assert!(issues
+            .iter()
+            .any(|issue| issue.code == "VERIFICATION_HISTORY_REQUIRED"));
+    }
+
+    #[test]
+    fn verification_analysis_rejects_a_summary_with_wrong_references() {
+        let mut result = completed_result_with_verification_history();
+        result
+            .verification_analysis
+            .as_mut()
+            .expect("analysis")
+            .latest_attempt_ref = Some("different-attempt".to_string());
+        let mut issues = Vec::new();
+
+        validate_verification_analysis(&result, &mut issues);
+
+        assert!(issues
+            .iter()
+            .any(|issue| issue.code == "VERIFICATION_ANALYSIS_REF_INVALID"));
+    }
+
+    #[test]
+    fn verification_analysis_rejects_unlinked_reverification_before_persistence() {
+        let mut result = completed_result_with_verification_history();
+        let (attempts, repairs, evidence) = {
+            let history = result
+                .verification_history
+                .as_mut()
+                .expect("verification history");
+            history
+                .attempts
+                .last_mut()
+                .expect("verification attempt")
+                .status = contracts::VerificationLifecycleStatus::Reverified;
+            (
+                history.attempts.clone(),
+                history.repairs.clone(),
+                history.evidence.clone(),
+            )
+        };
+        result.verification_attempt = attempts.last().cloned();
+        result
+            .delivery_result
+            .as_mut()
+            .expect("delivery result")
+            .status = contracts::VerificationLifecycleStatus::Reverified;
+        result.verification_analysis =
+            Some(VerificationAnalysisSummary::from_history_with_evidence(
+                &attempts,
+                &repairs,
+                result.delivery_result.as_ref(),
+                &result.training_telemetry,
+                &result.verification_findings,
+                Some(&evidence),
+            ));
+        let mut issues = Vec::new();
+
+        validate_verification_analysis(&result, &mut issues);
+
+        assert!(issues
+            .iter()
+            .any(|issue| issue.code == "VERIFICATION_HISTORY_INVALID"));
+    }
+
+    #[test]
+    fn canonical_task_result_keeps_verification_state_for_readback() {
+        let result = completed_result_with_verification_history();
+        let mut value = serde_json::to_value(result).expect("serialize TaskResult");
+        let object = value.as_object_mut().expect("TaskResult object");
+
+        project_task_result_to_canonical_fields(object);
+
+        assert!(object.contains_key("verificationHistory"));
+        assert!(object.contains_key("verificationAttempt"));
+        assert!(object.contains_key("deliveryResult"));
+        assert!(object.contains_key("verificationAnalysis"));
+    }
+
+    #[test]
+    fn verification_state_survives_task_result_persistence_round_trip() {
+        let result = completed_result_with_verification_history();
+        let persisted = serde_json::to_value(&result).expect("serialize TaskResult");
+        let restored: TaskResult =
+            serde_json::from_value(persisted.clone()).expect("restore TaskResult");
+
+        assert_eq!(restored.verification_history, result.verification_history);
+        assert_eq!(restored.verification_attempt, result.verification_attempt);
+        assert_eq!(restored.delivery_result, result.delivery_result);
+        assert_eq!(restored.verification_analysis, result.verification_analysis);
+
+        let mut canonical = persisted.as_object().expect("TaskResult object").clone();
+        project_task_result_to_canonical_fields(&mut canonical);
+
+        assert!(canonical.contains_key("verificationHistory"));
+        assert!(canonical.contains_key("verificationAttempt"));
+        assert!(canonical.contains_key("deliveryResult"));
+        assert!(canonical.contains_key("verificationAnalysis"));
     }
 }


### PR DESCRIPTION
## Summary

- add a structured verification history for evidence, repairs, re-verification, and delivery results
- validate verification state before task-result persistence and expose a read-only review projection
- add CI, security reporting, Dependabot configuration, and contribution guidance

## Verification

- cargo fmt --manifest-path src/rust/Cargo.toml --all --check
- cargo check --manifest-path src/rust/Cargo.toml --workspace
- cargo test --manifest-path src/rust/Cargo.toml -p contracts verification::tests
- cargo test --manifest-path src/rust/Cargo.toml -p execution

## Related Issue

N/A