### PR TITLE
fix(docx): support quick-xml 0.42

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -950,9 +950,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.38.4"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+checksum = "41b1177fdf999d2321d3fb46ff47159d9c1fb9ad66a4879f8c50a0b504615e9b"
 dependencies = [
  "memchr",
 ]

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -37,7 +37,7 @@ thiserror = "2.0"
 tokio = { version = "1.48", features = ["macros", "rt-multi-thread", "io-std", "signal"] }
 chrono = "0.4"
 fs2 = "0.4"
-quick-xml = "0.38"
+quick-xml = "0.42"
 zip = "6.0"
 pdf-extract = "0.9"
 toml_edit = "0.25"

--- a/src/rust/brainstorm/requirements.rs
+++ b/src/rust/brainstorm/requirements.rs
@@ -529,7 +529,7 @@ fn extract_docx_text(path: &Path) -> StateResult<String> {
     loop {
         match reader.read_event() {
             Ok(Event::Text(text)) => {
-                output.push_str(&text.decode().unwrap_or_default());
+                output.push_str(text.as_ref());
                 output.push(' ');
             }
             Ok(Event::Eof) => break,

--- a/src/rust/knowledge/builder.rs
+++ b/src/rust/knowledge/builder.rs
@@ -568,7 +568,7 @@ fn extract_docx_text(path: &Path) -> KnowledgeResult<String> {
     loop {
         match reader.read_event() {
             Ok(quick_xml::events::Event::Text(event)) => {
-                text.push_str(&String::from_utf8_lossy(event.as_ref()));
+                text.push_str(event.as_ref());
                 text.push('\n');
             }
             Ok(quick_xml::events::Event::Eof) => break,


### PR DESCRIPTION
Updates the quick-xml 0.42 migration for DOCX text extraction.\n\n- uses the new UTF-8 text event API\n- preserves the existing extracted text output\n\nValidated with cargo fmt, workspace check, and workspace library tests.