### PR TITLE
Improve delivery verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,12 @@ jobs:
       - name: Test workspace libraries
         run: cargo test --manifest-path src/rust/Cargo.toml --workspace --lib
 
+      - name: Test delivery lifecycle
+        run: cargo test --manifest-path src/rust/Cargo.toml -p mcp-server --tests -- --test-threads=1
+
+      - name: Test Rust algorithm worker bridge
+        run: PYTHON=python cargo test --manifest-path src/rust/Cargo.toml -p algorithm-client --test worker_smoke
+
       - name: Build release binaries
         run: cargo build --release --manifest-path src/rust/Cargo.toml -p mcp-server -p setup
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,21 @@ jobs:
             --output-dir dist/packages \
             --platform "${{ matrix.platform }}"
 
+      - name: Smoke test packaged runtime
+        if: matrix.rust_target == ''
+        shell: bash
+        run: |
+          set -euo pipefail
+          package_root="$(find dist/packages -mindepth 1 -maxdepth 1 -type d -name 'loom-*' | sort | head -n 1)"
+          extension=""
+          if [ "${{ matrix.platform }}" = "windows-x64" ]; then
+            extension=".exe"
+          fi
+          "$package_root/bin/loom-setup$extension" --version | grep -q '"status": "ok"'
+          printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"release-smoke","version":"0.0.1"}}}' \
+            | "$package_root/bin/loom-mcp-server$extension" \
+            | grep -q 'loom-mcp-server'
+
       - name: Create release archive
         shell: bash
         run: |

--- a/src/rust/contracts/ui_quality.rs
+++ b/src/rust/contracts/ui_quality.rs
@@ -649,7 +649,7 @@ fn ui_surface_state_model_shape() -> Value {
 
 fn ui_surface_composition_constraints_shape() -> Value {
     json!({
-        "requiredComposition": [UI_COMPOSITION_CONSTRAINT_KINDS.join(" | ")],
+        "requiredComposition": [UI_REGION_ROLES.join(" | ")],
         "forbiddenComposition": [UI_COMPOSITION_CONSTRAINT_KINDS.join(" | ")],
         "antiDemoRules": [UI_COMPOSITION_CONSTRAINT_KINDS.join(" | ")],
         "customRules": ["required when known constraints do not cover the product surface"]

--- a/src/rust/core/read_protocol.rs
+++ b/src/rust/core/read_protocol.rs
@@ -29,6 +29,66 @@ pub struct InspectRequestResult {
     pub submit_tool: Option<String>,
 }
 
+impl InspectRequestResult {
+    pub fn mcp_summary(self) -> InspectRequestSummary {
+        InspectRequestSummary {
+            request_ref: self.request_ref,
+            request_id: self.request_id,
+            project_id: self.project_id,
+            request_kind: self.request_kind,
+            read_groups: self
+                .read_groups
+                .into_iter()
+                .map(InspectReadGroupSummary::from)
+                .collect(),
+            write_targets: self.write_targets,
+            submit_tool: self.submit_tool,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct InspectRequestSummary {
+    pub request_ref: String,
+    pub request_id: String,
+    pub project_id: String,
+    pub request_kind: String,
+    pub read_groups: Vec<InspectReadGroupSummary>,
+    pub write_targets: Vec<Value>,
+    pub submit_tool: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct InspectReadGroupSummary {
+    pub group_id: String,
+    pub required: bool,
+    pub order: u32,
+    pub purpose: String,
+    pub when_to_read: String,
+    pub projection_mode: String,
+    pub field_count: usize,
+    pub read_tool: String,
+    pub resource_uri: String,
+}
+
+impl From<ReadGroupRef> for InspectReadGroupSummary {
+    fn from(group: ReadGroupRef) -> Self {
+        Self {
+            field_count: group.expanded_fields().len(),
+            group_id: group.group_id,
+            required: group.required,
+            order: group.order,
+            purpose: group.purpose,
+            when_to_read: group.when_to_read,
+            projection_mode: group.projection_mode,
+            read_tool: group.read_tool,
+            resource_uri: group.resource_uri,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct ReadFieldGroupInput {

--- a/src/rust/mcp-server/server.rs
+++ b/src/rust/mcp-server/server.rs
@@ -3,10 +3,11 @@ use std::future::{ready, Future};
 use brainstorm::{accept_brainstorm_file, BrainstormConfirmBlockInput};
 use delivery_core::{
     is_submit_tool, normalize_project_root, status_details, submit_tool_spec, validate_plan_input,
-    DomainDispatcher, FileSubmitInput, InspectRequestInput, LoomMcpActionResult, LoomMcpDoneResult,
-    LoomMcpFailure, LoomMcpFailureResult, LoomMcpRepairableErrorResult, LoomMcpRuntimeContext,
-    OperationContext, PlanConflictChoice, PlanConflictResolveInput, PlanToolInput,
-    ProjectToolInput, ReadFieldGroupInput, SubmitAcceptedEvent, TransitionEngine, TransitionStore,
+    DomainDispatcher, FileSubmitInput, InspectRequestInput, InspectRequestResult,
+    LoomMcpActionResult, LoomMcpDoneResult, LoomMcpFailure, LoomMcpFailureResult,
+    LoomMcpRepairableErrorResult, LoomMcpRuntimeContext, OperationContext, PlanConflictChoice,
+    PlanConflictResolveInput, PlanToolInput, ProjectToolInput, ReadFieldGroupInput,
+    SubmitAcceptedEvent, TransitionEngine, TransitionStore,
 };
 use deploy::{DeployBootstrapInput, DeployToolInput};
 use execution::{VsefmToolInput, VsefmVerificationResolveInput};
@@ -152,8 +153,14 @@ fn call_tool(
     server: &LoomMcpServer,
     request: CallToolRequestParams,
 ) -> Result<CallToolResult, McpError> {
-    let tool_name = canonical_tool_name(request.name.as_ref());
-    match tool_name {
+    let tool_name = canonical_tool_name(request.name.as_ref()).to_string();
+    let project_root = request
+        .arguments
+        .as_ref()
+        .and_then(|arguments| arguments.get("projectRoot"))
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string);
+    let result = match tool_name.as_str() {
         "initProject" => action_result(init_project_tool(parse_args::<ProjectToolInput>(
             request.arguments,
         )?)),
@@ -185,9 +192,10 @@ fn call_tool(
         >(
             request.arguments,
         )?)),
-        "inspectRequest" => structured(state::inspect_request(parse_args::<InspectRequestInput>(
-            request.arguments,
-        )?)),
+        "inspectRequest" => structured(
+            state::inspect_request(parse_args::<InspectRequestInput>(request.arguments)?)
+                .map(InspectRequestResult::mcp_summary),
+        ),
         "readFieldGroup" => structured(state::read_field_group(parse_args::<ReadFieldGroupInput>(
             request.arguments,
         )?)),
@@ -364,9 +372,35 @@ fn call_tool(
         )),
         _ => server
             .tools
-            .call_registered_placeholder(tool_name, request.arguments)
+            .call_registered_placeholder(&tool_name, request.arguments)
             .map_err(|_| McpError::method_not_found::<CallToolRequestMethod>()),
+    };
+    if let (Some(project_root), Ok(response)) = (project_root.as_deref(), result.as_ref()) {
+        record_mcp_response(project_root, &tool_name, response);
     }
+    result
+}
+
+fn record_mcp_response(project_root: &str, tool_name: &str, response: &CallToolResult) {
+    let Ok(value) = serde_json::to_value(response) else {
+        return;
+    };
+    let state = value
+        .get("structuredContent")
+        .and_then(|content| content.get("state"))
+        .and_then(serde_json::Value::as_str);
+    let Ok(serialized) = serde_json::to_vec(&value) else {
+        return;
+    };
+    state::read_audit::record_mcp_response_audit(
+        project_root,
+        state::read_audit::McpResponseAudit {
+            tool_name,
+            state,
+            serialized_bytes: serialized.len(),
+            recorded_at: state::read_audit::now_for_audit(),
+        },
+    );
 }
 
 fn canonical_tool_name(name: &str) -> &str {

--- a/src/rust/mcp-server/tool_registry.rs
+++ b/src/rust/mcp-server/tool_registry.rs
@@ -2,7 +2,7 @@ use std::{borrow::Cow, sync::Arc};
 
 use brainstorm::BrainstormConfirmBlockInput;
 use delivery_core::{
-    normalize_project_root, FileSubmitInput, InspectRequestInput, InspectRequestResult,
+    normalize_project_root, FileSubmitInput, InspectRequestInput, InspectRequestSummary,
     LoomMcpActionResult, PlanConflictResolveInput, PlanToolInput, ProjectToolInput,
     ReadFieldGroupInput, ReadFieldGroupResult,
 };
@@ -536,7 +536,7 @@ fn input_schema(kind: ToolInputKind) -> Arc<JsonObject> {
 fn output_schema(kind: ToolOutputKind) -> JsonObject {
     match kind {
         ToolOutputKind::ActionResult => schema_json_object::<LoomMcpActionResult>(),
-        ToolOutputKind::InspectRequest => schema_json_object::<InspectRequestResult>(),
+        ToolOutputKind::InspectRequest => schema_json_object::<InspectRequestSummary>(),
         ToolOutputKind::ReadFieldGroup => schema_json_object::<ReadFieldGroupResult>(),
     }
 }

--- a/src/rust/state/paths.rs
+++ b/src/rust/state/paths.rs
@@ -20,6 +20,7 @@ pub struct ProjectPaths {
     pub metrics_dir: PathBuf,
     pub request_size_audit_file: PathBuf,
     pub field_read_audit_file: PathBuf,
+    pub mcp_response_audit_file: PathBuf,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -52,6 +53,7 @@ pub fn project_paths(project_root: &str) -> StateResult<ProjectPaths> {
         request_index_file: requests_dir.join("index.json"),
         request_size_audit_file: metrics_dir.join("request-size-audit.jsonl"),
         field_read_audit_file: metrics_dir.join("field-read-audit.jsonl"),
+        mcp_response_audit_file: metrics_dir.join("mcp-response-audit.jsonl"),
         loom_dir,
         requests_dir,
         metrics_dir,

--- a/src/rust/state/read_audit.rs
+++ b/src/rust/state/read_audit.rs
@@ -44,12 +44,26 @@ pub struct FieldReadAudit<'a> {
     pub recorded_at: String,
 }
 
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct McpResponseAudit<'a> {
+    pub tool_name: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state: Option<&'a str>,
+    pub serialized_bytes: usize,
+    pub recorded_at: String,
+}
+
 pub fn record_request_size_audit(project_root: &str, audit: RequestSizeAudit<'_>) {
     let _ = append_json_line(project_root, AuditFile::RequestSize, &audit);
 }
 
 pub fn record_field_read_audit(project_root: &str, audit: FieldReadAudit<'_>) {
     let _ = append_json_line(project_root, AuditFile::FieldRead, &audit);
+}
+
+pub fn record_mcp_response_audit(project_root: &str, audit: McpResponseAudit<'_>) {
+    let _ = append_json_line(project_root, AuditFile::McpResponse, &audit);
 }
 
 pub fn record_request_inspect_audit(project_root: &str, request_ref: &str, request_id: &str) {
@@ -160,6 +174,7 @@ fn read_audit_entries(project_root: &str) -> Vec<serde_json::Value> {
 enum AuditFile {
     RequestSize,
     FieldRead,
+    McpResponse,
 }
 
 fn append_json_line(
@@ -168,10 +183,14 @@ fn append_json_line(
     value: &impl Serialize,
 ) -> StateResult<()> {
     let paths = project_paths(project_root)?;
+    if !paths.loom_dir.is_dir() {
+        return Ok(());
+    }
     ensure_dir(&paths.metrics_dir)?;
     let file = match kind {
         AuditFile::RequestSize => paths.request_size_audit_file,
         AuditFile::FieldRead => paths.field_read_audit_file,
+        AuditFile::McpResponse => paths.mcp_response_audit_file,
     };
     let line = format!("{}\n", serde_json::to_string(value)?);
     use std::io::Write;

--- a/src/rust/verification/lib.rs
+++ b/src/rust/verification/lib.rs
@@ -164,6 +164,9 @@ struct TokenReadPlanSummary {
     request_count: usize,
     total_payload_bytes: u64,
     max_compact_bytes: u64,
+    mcp_response_count: usize,
+    total_mcp_response_bytes: u64,
+    max_mcp_response_bytes: u64,
     total_field_read_count: usize,
     read_field_group_count: usize,
     read_request_fields_count: usize,
@@ -773,6 +776,7 @@ fn build_token_summary(
     let paths = state::paths::project_paths(project_root)?;
     let request_audits = read_jsonl(&paths.request_size_audit_file)?;
     let field_audits = read_jsonl(&paths.field_read_audit_file)?;
+    let response_audits = read_jsonl(&paths.mcp_response_audit_file)?;
     let total_payload_bytes = request_audits
         .iter()
         .map(|value| {
@@ -785,6 +789,15 @@ fn build_token_summary(
     let max_compact_bytes = request_audits
         .iter()
         .filter_map(|value| value.get("compactBytes").and_then(Value::as_u64))
+        .max()
+        .unwrap_or(0);
+    let total_mcp_response_bytes = response_audits
+        .iter()
+        .filter_map(|value| value.get("serializedBytes").and_then(Value::as_u64))
+        .sum::<u64>();
+    let max_mcp_response_bytes = response_audits
+        .iter()
+        .filter_map(|value| value.get("serializedBytes").and_then(Value::as_u64))
         .max()
         .unwrap_or(0);
     let read_field_group_count = field_audits
@@ -868,6 +881,9 @@ fn build_token_summary(
         request_count: request_audits.len(),
         total_payload_bytes,
         max_compact_bytes,
+        mcp_response_count: response_audits.len(),
+        total_mcp_response_bytes,
+        max_mcp_response_bytes,
         total_field_read_count: field_audits.len(),
         read_field_group_count,
         read_request_fields_count,

--- a/tests/rust/algorithm-client/worker_smoke.rs
+++ b/tests/rust/algorithm-client/worker_smoke.rs
@@ -14,7 +14,7 @@ fn repo_root() -> PathBuf {
 fn client() -> AlgorithmClient {
     let root = repo_root();
     AlgorithmClient::new(
-        "python3",
+        std::env::var("PYTHON").unwrap_or_else(|_| "python3".to_string()),
         root.join("src")
             .join("python")
             .join("algorithms")

--- a/tests/rust/mcp-server/server_smoke.rs
+++ b/tests/rust/mcp-server/server_smoke.rs
@@ -1,6 +1,8 @@
 use std::{
     io::{BufRead, BufReader, Write},
+    path::{Path, PathBuf},
     process::{Child, ChildStdin, ChildStdout, Command, Stdio},
+    time::{SystemTime, UNIX_EPOCH},
 };
 
 use serde_json::{json, Value};
@@ -100,6 +102,98 @@ fn stdio_server_initializes_and_lists_batch_2_surface() {
     );
 }
 
+#[test]
+fn stdio_server_persists_and_reads_a_delivery_request() {
+    let fixture = TestProject::new("delivery-lifecycle");
+    let mut client = McpProcess::start_with_loom_home(&fixture.loom_home);
+    client.initialize();
+
+    let initialized = client.call_tool(
+        1,
+        "loom.initProject",
+        json!({ "projectRoot": fixture.project_root }),
+    );
+    assert_eq!(initialized["result"]["structuredContent"]["state"], "done");
+    assert!(fixture.project_root.join(".loom/status.json").exists());
+
+    let planned = client.call_tool(
+        2,
+        "loom.plan",
+        json!({
+            "projectRoot": fixture.project_root,
+            "requestText": "Add an account search flow with tests and a clear handoff."
+        }),
+    );
+    let plan = &planned["result"]["structuredContent"];
+    assert_eq!(plan["state"], "user_gate", "{plan:#}");
+    let request_ref = plan["requestRef"].as_str().expect("request ref");
+
+    let inspected = client.call_tool(
+        3,
+        "loom.inspectRequest",
+        json!({
+            "projectRoot": fixture.project_root,
+            "requestRef": request_ref
+        }),
+    );
+    let inspection = &inspected["result"]["structuredContent"];
+    assert_eq!(inspection["requestRef"], request_ref);
+    assert!(inspection["readGroups"]
+        .as_array()
+        .is_some_and(|groups| !groups.is_empty()));
+    let first_group = &inspection["readGroups"][0];
+    assert!(first_group["fieldCount"].is_u64());
+    assert!(first_group.get("selectors").is_none());
+
+    let read = client.call_tool(
+        4,
+        "loom.readFieldGroup",
+        json!({
+            "projectRoot": fixture.project_root,
+            "requestRef": request_ref,
+            "groupId": "conversation_protocol"
+        }),
+    );
+    assert!(
+        read["result"]["structuredContent"]["fields"]["clarificationConversationProtocol"]
+            .is_object()
+    );
+}
+
+struct TestProject {
+    root: PathBuf,
+    project_root: PathBuf,
+    loom_home: PathBuf,
+}
+
+impl TestProject {
+    fn new(name: &str) -> Self {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time after epoch")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "loom-mcp-stdio-{name}-{}-{nonce}",
+            std::process::id()
+        ));
+        let project_root = root.join("project");
+        let loom_home = root.join("loom-home");
+        std::fs::create_dir_all(&project_root).expect("create project root");
+        std::fs::create_dir_all(&loom_home).expect("create Loom home");
+        Self {
+            root,
+            project_root,
+            loom_home,
+        }
+    }
+}
+
+impl Drop for TestProject {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.root);
+    }
+}
+
 struct McpProcess {
     child: Child,
     stdin: ChildStdin,
@@ -108,7 +202,15 @@ struct McpProcess {
 
 impl McpProcess {
     fn start() -> Self {
-        let mut child = Command::new(env!("CARGO_BIN_EXE_loom-mcp-server"))
+        Self::start_with_loom_home(Path::new(""))
+    }
+
+    fn start_with_loom_home(loom_home: &Path) -> Self {
+        let mut command = Command::new(env!("CARGO_BIN_EXE_loom-mcp-server"));
+        if !loom_home.as_os_str().is_empty() {
+            command.env("LOOM_HOME", loom_home);
+        }
+        let mut child = command
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
@@ -130,6 +232,36 @@ impl McpProcess {
 
     fn notify(&mut self, notification: Value) {
         self.write_message(&notification);
+    }
+
+    fn initialize(&mut self) {
+        let initialized = self.request(json!({
+            "jsonrpc": "2.0",
+            "id": 0,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-11-25",
+                "capabilities": {},
+                "clientInfo": { "name": "loom-test-client", "version": "0.0.1" }
+            }
+        }));
+        assert_eq!(
+            initialized["result"]["serverInfo"]["name"],
+            "loom-mcp-server"
+        );
+        self.notify(json!({
+            "jsonrpc": "2.0",
+            "method": "notifications/initialized"
+        }));
+    }
+
+    fn call_tool(&mut self, id: u64, name: &str, arguments: Value) -> Value {
+        self.request(json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": "tools/call",
+            "params": { "name": name, "arguments": arguments }
+        }))
     }
 
     fn write_message(&mut self, value: &Value) {

--- a/tests/rust/mcp-server/server_smoke.rs
+++ b/tests/rust/mcp-server/server_smoke.rs
@@ -158,6 +158,15 @@ fn stdio_server_persists_and_reads_a_delivery_request() {
         read["result"]["structuredContent"]["fields"]["clarificationConversationProtocol"]
             .is_object()
     );
+    let response_audit = std::fs::read_to_string(
+        fixture
+            .project_root
+            .join(".loom/metrics/mcp-response-audit.jsonl"),
+    )
+    .expect("MCP response audit");
+    assert!(response_audit.contains("\"toolName\":\"plan\""));
+    assert!(response_audit.contains("\"toolName\":\"readFieldGroup\""));
+    assert!(response_audit.contains("\"serializedBytes\":"));
 }
 
 struct TestProject {

--- a/tests/rust/mcp-server/submit_tools.rs
+++ b/tests/rust/mcp-server/submit_tools.rs
@@ -12669,7 +12669,7 @@ fn frontend_surface_decision_candidate_json() -> Value {
             "desktop": {
                 "layoutIntent": "Keep navigation, filters, results, and the primary action visible in the work region.",
                 "allowedPresentations": ["table", "detail_panel", "form_sections"],
-                "forbiddenPresentations": ["no_marketing_hero"]
+                "forbiddenPresentations": ["chart_panel"]
             },
             "tablet": {
                 "layoutIntent": "Keep record scanning first and move secondary detail into a supporting region.",

--- a/tests/rust/setup/setup_workflow.rs
+++ b/tests/rust/setup/setup_workflow.rs
@@ -906,6 +906,8 @@ fn release_workflow_uploads_installers_packages_and_checksums() {
     assert!(workflow.contains("install.ps1.sha256"));
     assert!(workflow.contains(".tar.gz.sha256"));
     assert!(workflow.contains(".zip.sha256"));
+    assert!(workflow.contains("Smoke test packaged runtime"));
+    assert!(workflow.contains("release-smoke"));
     assert!(workflow.contains("softprops/action-gh-release@v3"));
     assert!(workflow.contains("make_latest: true"));
 }


### PR DESCRIPTION
## Summary
- strengthen verification coverage across CI, release packages, and MCP lifecycle paths
- compact repeated MCP inspection payloads while preserving durable state access
- record MCP response-size telemetry for measured follow-up work

## Verification
- cargo test -p mcp-server --tests -- --test-threads=1
- cargo test -p mcp-server --test verify_tools -- --test-threads=1
- cargo test -p verification --test final_regression